### PR TITLE
[product] feat: 상품 가격 추가, 상품 옵션 추가금액 추가

### DIFF
--- a/product/src/main/java/com/emotionalcart/core/feature/product/Product.java
+++ b/product/src/main/java/com/emotionalcart/core/feature/product/Product.java
@@ -24,15 +24,20 @@ public class Product extends BaseEntity {
     @NotNull
     private String description;
 
+    @NotNull
+    private Integer price;
+
     private Product(
             Long id,
             Long categoryId,
             String name,
-            String description
+            String description,
+            Integer price
     ) {
         this.id = id;
         this.categoryId = categoryId;
         this.name = name;
         this.description = description;
+        this.price = price;
     }
 }

--- a/product/src/main/java/com/emotionalcart/core/feature/product/ProductOptionDetail.java
+++ b/product/src/main/java/com/emotionalcart/core/feature/product/ProductOptionDetail.java
@@ -31,20 +31,19 @@ public class ProductOptionDetail extends BaseEntity {
     @NotNull
     private Integer optionDetailOrder;
 
-    @NotNull
-    private Integer sellPrice;
+    private Integer additionalPrice;
 
     private ProductOptionDetail(
             Long productOptionId,
             String value,
             Integer quantity,
             Integer optionDetailOrder,
-            Integer sellPrice
+            Integer additionalPrice
     ) {
         this.productOptionId = productOptionId;
         this.value = value;
         this.quantity = quantity;
         this.optionDetailOrder = optionDetailOrder;
-        this.sellPrice = sellPrice;
+        this.additionalPrice = additionalPrice;
     }
 }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* 상품옵션상세에만 상품의 가격이 존재하면, 옵션을 선택하지 않는 한 상품의 기본 가격을 알 수 없음
* 목록 조회 시 상품 가격 조회 불가능해보임

# 어떻게 해결했나요?

* 상품에 price (기본가격) 추가
* 상품옵션상세에 additional_price (옵션 가격 +/-) 추가

## Attachment

<img width="914" alt="image" src="https://github.com/user-attachments/assets/8a7a7274-fe6f-4149-ad34-232144e4f4e4" />
## PN 규칙

p1 : 적극적으로 고려해주세요 (Request changes)
리뷰를 받아들이거나 그럴수 없다면 토론을 해보자

p2 : 웬만하면 반영해 주세요 (Comment)
리뷰를 받아들이거나 그럴수 없다면 다음에 반영할 계획을 명시적으로(업무) 표현하자

p3 : 반영해도 좋고 넘어가도 좋습니다. (Approve)
의견에 대해 고민해보자

p4 : 그냥 사소한 의견입니다. (Approve)

# 주의점 및 기타 사항

* 제가 생각하기엔 이게 맞아보이는데 아닌 것 같다면 의견 주세요. 
