### PR TITLE
[주문] 주문 통계 및 카테고리 별 상품 최대 판매량 조회 API 추가

### DIFF
--- a/order/build.gradle.kts
+++ b/order/build.gradle.kts
@@ -18,6 +18,7 @@ java {
 repositories {
     mavenCentral()
 }
+
 dependencies {
     implementation(project(":common"))
     implementation("org.springframework.boot:spring-boot-starter")
@@ -37,6 +38,10 @@ dependencies {
 
     // https://mvnrepository.com/artifact/org.redisson/redisson-spring-boot-starter
     implementation("org.redisson:redisson-spring-boot-starter:$redissonVersion")
+
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
     annotationProcessor("org.projectlombok:lombok")
     // https://mvnrepository.com/artifact/org.projectlombok/lombok
@@ -58,7 +63,7 @@ dependencies {
 
     testAnnotationProcessor("org.projectlombok:lombok")
     testCompileOnly("org.projectlombok:lombok")
-    
+
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     // https://mvnrepository.com/artifact/com.tngtech.archunit/archunit-junit5
     testImplementation("com.tngtech.archunit:archunit-junit5:$archunitVersion")

--- a/order/src/main/java/com/emotionalcart/OrderApplication.java
+++ b/order/src/main/java/com/emotionalcart/OrderApplication.java
@@ -4,7 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @EnableFeignClients
 @EnableJpaAuditing
 @SpringBootApplication

--- a/order/src/main/java/com/emotionalcart/order/application/service/OrderStatisticsService.java
+++ b/order/src/main/java/com/emotionalcart/order/application/service/OrderStatisticsService.java
@@ -1,0 +1,28 @@
+package com.emotionalcart.order.application.service;
+
+import com.emotionalcart.order.domain.dto.BestSellingProduct;
+import com.emotionalcart.order.infra.order.OrderStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderStatisticsService {
+
+    private final OrderStatisticsRepository orderStatisticsRepository;
+
+    /**
+     * 카테고리 별로 상품 순위 조회
+     *
+     * @param categoryId 자식 카테고리 식별자
+     * @param request    페이징
+     * @return
+     */
+    public List<BestSellingProduct> getProductRankingByCategoryId(Long categoryId, PageRequest request) {
+        return orderStatisticsRepository.getProductRankingsByCategoryId(categoryId, request);
+    }
+
+}

--- a/order/src/main/java/com/emotionalcart/order/application/service/OrderStatisticsService.java
+++ b/order/src/main/java/com/emotionalcart/order/application/service/OrderStatisticsService.java
@@ -3,10 +3,9 @@ package com.emotionalcart.order.application.service;
 import com.emotionalcart.order.domain.dto.BestSellingProduct;
 import com.emotionalcart.order.infra.order.OrderStatisticsRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +20,7 @@ public class OrderStatisticsService {
      * @param request    페이징
      * @return
      */
-    public List<BestSellingProduct> getProductRankingByCategoryId(Long categoryId, PageRequest request) {
+    public Page<BestSellingProduct> getProductRankingByCategoryId(Long categoryId, Pageable request) {
         return orderStatisticsRepository.getProductRankingsByCategoryId(categoryId, request);
     }
 

--- a/order/src/main/java/com/emotionalcart/order/domain/dto/BestSellingProduct.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/dto/BestSellingProduct.java
@@ -1,0 +1,29 @@
+package com.emotionalcart.order.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BestSellingProduct {
+
+    /**
+     * 상품 아이디
+     */
+    private Long productId;
+
+    /**
+     * 카테고리 식별자
+     * 카테고리 식별자는 최하위 자식 카테고리만 저장
+     */
+    private Long categoryId;
+
+    /**
+     * 주문 건 수
+     */
+    private Long totalOrder;
+
+    /**
+     * 총 판매 횟 수
+     */
+    private Long totalQuantitySold;
+
+}

--- a/order/src/main/java/com/emotionalcart/order/domain/dto/BestSellingProduct.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/dto/BestSellingProduct.java
@@ -1,8 +1,13 @@
 package com.emotionalcart.order.domain.dto;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class BestSellingProduct {
 
     /**

--- a/order/src/main/java/com/emotionalcart/order/domain/dto/BestSellingProduct.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/dto/BestSellingProduct.java
@@ -26,4 +26,9 @@ public class BestSellingProduct {
      */
     private Long totalQuantitySold;
 
+    public BestSellingProduct(Long productId, Long categoryId) {
+        this.productId = productId;
+        this.categoryId = categoryId;
+    }
+
 }

--- a/order/src/main/java/com/emotionalcart/order/domain/dto/CreateOrder.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/dto/CreateOrder.java
@@ -60,14 +60,16 @@ public class CreateOrder extends SelfValidation<CreateOrder> {
      * @param productName     상품명
      * @param price           상품 금액
      * @param quantity        수량
+     * @param categoryId      카테고리 식별자
      */
-    public void addItem(Long productId, Long productOptionId, String productName, double price, int quantity) {
+    public void addItem(Long productId, Long productOptionId, Long categoryId, String productName, double price, int quantity) {
         if (CollectionUtils.isEmpty(orderItems)) {
             orderItems = new ArrayList<>();
         }
         orderItems.add(CreateOrderItem.builder()
                            .productId(productId)
                            .productOptionId(productOptionId)
+                           .categoryId(categoryId)
                            .productName(productName)
                            .price(price)
                            .quantity(quantity)

--- a/order/src/main/java/com/emotionalcart/order/domain/dto/CreateOrderItem.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/dto/CreateOrderItem.java
@@ -29,6 +29,12 @@ public class CreateOrderItem extends SelfValidation<CreateOrderItem> {
     private Long productOptionId;
 
     /**
+     * 카테고리 식별자
+     */
+    @NotNull(message = "상품 카테고리를 확인해주세요.")
+    private Long categoryId;
+
+    /**
      * 상품명
      */
     @NotNull(message = "상품명을 입력해주세요.")

--- a/order/src/main/java/com/emotionalcart/order/domain/entity/OrderStatistics.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/entity/OrderStatistics.java
@@ -3,8 +3,8 @@ package com.emotionalcart.order.domain.entity;
 import com.emotionalcart.order.domain.dto.CreateOrderItem;
 import com.emotionalcart.order.domain.generator.IdGenerator;
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
  * 주문 통계 테이블
  */
 @Getter
-@Table
+@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderStatistics extends AuditableEntity {
 

--- a/order/src/main/java/com/emotionalcart/order/domain/entity/OrderStatistics.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/entity/OrderStatistics.java
@@ -31,7 +31,8 @@ public class OrderStatistics extends AuditableEntity {
     private Long productId;
 
     /**
-     * 카테고리 아이디
+     * 카테고리 식별자
+     * 카테고리 식별자는 최하위 자식 카테고리만 저장
      */
     @Column(nullable = false)
     private Long categoryId;

--- a/order/src/main/java/com/emotionalcart/order/domain/entity/OrderStatistics.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/entity/OrderStatistics.java
@@ -1,0 +1,71 @@
+package com.emotionalcart.order.domain.entity;
+
+import com.emotionalcart.order.domain.dto.CreateOrderItem;
+import com.emotionalcart.order.domain.generator.IdGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+/**
+ * 주문 통계 테이블
+ */
+@Getter
+@Table
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderStatistics extends AuditableEntity {
+
+    @Id
+    @IdGenerator
+    private Long id;
+
+    /**
+     * 상품 아이디
+     */
+    @Column(nullable = false)
+    private Long productId;
+
+    /**
+     * 카테고리 아이디
+     */
+    @Column(nullable = false)
+    private Long categoryId;
+
+    /**
+     * 주문 건 수
+     */
+    private Long totalOrder;
+
+    /**
+     * 총 판매 횟 수
+     */
+    private Long totalQuantitySold;
+
+    /**
+     * 마지막 주문 시간
+     */
+    @LastModifiedDate
+    private LocalDateTime lastOrderedAt;
+
+    public OrderStatistics(CreateOrderItem orderItem) {
+        this.productId = orderItem.getProductId();
+        this.categoryId = orderItem.getCategoryId();
+        this.totalOrder = 0L;
+        this.totalQuantitySold = 0L;
+    }
+
+    public static OrderStatistics create(CreateOrderItem orderItem) {
+        return new OrderStatistics(orderItem);
+    }
+
+    public void updateOrderStatistics(CreateOrderItem orderItem) {
+        this.totalOrder++;
+        this.totalQuantitySold += orderItem.getQuantity();
+    }
+
+}

--- a/order/src/main/java/com/emotionalcart/order/infra/config/JpaConfig.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/config/JpaConfig.java
@@ -1,0 +1,20 @@
+package com.emotionalcart.order.infra.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsQuerydsl.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsQuerydsl.java
@@ -1,0 +1,12 @@
+package com.emotionalcart.order.infra.order;
+
+import com.emotionalcart.order.domain.dto.BestSellingProduct;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+public interface OrderStatisticsQuerydsl {
+
+    List<BestSellingProduct> getProductRankingsByCategoryId(Long categoryId, PageRequest page);
+
+}

--- a/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsQuerydsl.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsQuerydsl.java
@@ -1,12 +1,11 @@
 package com.emotionalcart.order.infra.order;
 
 import com.emotionalcart.order.domain.dto.BestSellingProduct;
-import org.springframework.data.domain.PageRequest;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderStatisticsQuerydsl {
 
-    List<BestSellingProduct> getProductRankingsByCategoryId(Long categoryId, PageRequest page);
+    Page<BestSellingProduct> getProductRankingsByCategoryId(Long categoryId, Pageable page);
 
 }

--- a/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsRepository.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface OrderStatisticsRepository extends JpaRepository<OrderStatistics, Long> {
+public interface OrderStatisticsRepository extends JpaRepository<OrderStatistics, Long>, OrderStatisticsQuerydsl {
 
     Optional<OrderStatistics> findByProductIdAndCategoryId(@NotNull(message = "상품을 선택해주세요.") Long productId,
                                                            @NotNull(message = "상품 카테고리를 확인해주세요.") Long categoryId);

--- a/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsRepository.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/OrderStatisticsRepository.java
@@ -1,0 +1,14 @@
+package com.emotionalcart.order.infra.order;
+
+import com.emotionalcart.order.domain.entity.OrderStatistics;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrderStatisticsRepository extends JpaRepository<OrderStatistics, Long> {
+
+    Optional<OrderStatistics> findByProductIdAndCategoryId(@NotNull(message = "상품을 선택해주세요.") Long productId,
+                                                           @NotNull(message = "상품 카테고리를 확인해주세요.") Long categoryId);
+
+}

--- a/order/src/main/java/com/emotionalcart/order/infra/order/impl/OrderStatisticsRepositoryImpl.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/impl/OrderStatisticsRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.emotionalcart.order.infra.order.impl;
+
+import com.emotionalcart.order.domain.dto.BestSellingProduct;
+import com.emotionalcart.order.domain.entity.QOrderStatistics;
+import com.emotionalcart.order.infra.order.OrderStatisticsQuerydsl;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPQLQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class OrderStatisticsRepositoryImpl implements OrderStatisticsQuerydsl {
+
+    private final JPQLQueryFactory queryFactory;
+
+    @Override
+    public List<BestSellingProduct> getProductRankingsByCategoryId(Long categoryId, PageRequest page) {
+        QOrderStatistics orderStatistics = QOrderStatistics.orderStatistics;
+        return queryFactory.select(Projections.constructor(
+                BestSellingProduct.class,
+                orderStatistics.productId,
+                orderStatistics.categoryId,
+                orderStatistics.totalOrder,
+                orderStatistics.totalQuantitySold
+            )).from(orderStatistics)
+            .where(orderStatistics.categoryId.eq(categoryId))
+            .orderBy(orderStatistics.totalQuantitySold.desc())
+            .offset(page.getOffset())
+            .limit(page.getPageSize()).fetch();
+    }
+
+}

--- a/order/src/main/java/com/emotionalcart/order/infra/order/impl/OrderStatisticsRepositoryImpl.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/impl/OrderStatisticsRepositoryImpl.java
@@ -4,11 +4,13 @@ import com.emotionalcart.order.domain.dto.BestSellingProduct;
 import com.emotionalcart.order.domain.entity.QOrderStatistics;
 import com.emotionalcart.order.infra.order.OrderStatisticsQuerydsl;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQueryFactory;
+import com.querydsl.jpa.impl.JPAQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
@@ -17,23 +19,43 @@ public class OrderStatisticsRepositoryImpl implements OrderStatisticsQuerydsl {
 
     private final JPQLQueryFactory queryFactory;
 
+    public static BooleanExpression hasCategoryId(Long categoryId) {
+        return categoryId != null ? QOrderStatistics.orderStatistics.categoryId.eq(categoryId) : null;
+    }
+
+    public static BooleanExpression hasProductId(Long productId) {
+        return productId != null ? QOrderStatistics.orderStatistics.productId.eq(productId) : null;
+    }
+
     @Override
     public Page<BestSellingProduct> getProductRankingsByCategoryId(Long categoryId, Pageable page) {
         QOrderStatistics orderStatistics = QOrderStatistics.orderStatistics;
-        List<BestSellingProduct> content = queryFactory.select(Projections.constructor(
+
+        // 공통 조건을 static 메서드로 분리하여 사용
+        BooleanExpression categoryCondition = hasCategoryId(categoryId);
+
+        // 데이터 조회 쿼리
+        List<BestSellingProduct> content = queryFactory
+            .select(Projections.constructor(
                 BestSellingProduct.class,
                 orderStatistics.productId,
                 orderStatistics.categoryId,
                 orderStatistics.totalOrder,
                 orderStatistics.totalQuantitySold
-            )).from(orderStatistics)
-            .where(orderStatistics.categoryId.eq(categoryId))
+            ))
+            .from(orderStatistics)
+            .where(categoryCondition)
             .orderBy(orderStatistics.totalQuantitySold.desc())
             .offset(page.getOffset())
-            .limit(page.getPageSize()).fetch();
-        long count = queryFactory.select(orderStatistics.count()).from(orderStatistics)
-            .where(orderStatistics.categoryId.eq(categoryId)).fetchCount();
-        return new PageImpl<>(content, page, count);
+            .limit(page.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = (JPAQuery<Long>)queryFactory
+            .select(orderStatistics.count())
+            .from(orderStatistics)
+            .where(categoryCondition);
+
+        return PageableExecutionUtils.getPage(content, page, countQuery::fetchOne);
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/infra/order/impl/OrderStatisticsRepositoryImpl.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/impl/OrderStatisticsRepositoryImpl.java
@@ -6,7 +6,9 @@ import com.emotionalcart.order.infra.order.OrderStatisticsQuerydsl;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPQLQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -16,9 +18,9 @@ public class OrderStatisticsRepositoryImpl implements OrderStatisticsQuerydsl {
     private final JPQLQueryFactory queryFactory;
 
     @Override
-    public List<BestSellingProduct> getProductRankingsByCategoryId(Long categoryId, PageRequest page) {
+    public Page<BestSellingProduct> getProductRankingsByCategoryId(Long categoryId, Pageable page) {
         QOrderStatistics orderStatistics = QOrderStatistics.orderStatistics;
-        return queryFactory.select(Projections.constructor(
+        List<BestSellingProduct> content = queryFactory.select(Projections.constructor(
                 BestSellingProduct.class,
                 orderStatistics.productId,
                 orderStatistics.categoryId,
@@ -29,6 +31,9 @@ public class OrderStatisticsRepositoryImpl implements OrderStatisticsQuerydsl {
             .orderBy(orderStatistics.totalQuantitySold.desc())
             .offset(page.getOffset())
             .limit(page.getPageSize()).fetch();
+        long count = queryFactory.select(orderStatistics.count()).from(orderStatistics)
+            .where(orderStatistics.categoryId.eq(categoryId)).fetchCount();
+        return new PageImpl<>(content, page, count);
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderApiDocs.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderApiDocs.java
@@ -1,0 +1,22 @@
+package com.emotionalcart.order.presentation.controller;
+
+import com.emotionalcart.order.presentation.controller.request.CreateOrderRequest;
+import com.emotionalcart.order.presentation.controller.response.CreatedOrderResponse;
+import com.emotionalcart.order.presentation.controller.response.OrderDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "주문", description = "주문 API")
+public interface OrderApiDocs {
+
+    @Operation(summary = "주문하기 API")
+    ResponseEntity<CreatedOrderResponse> createOrder(@RequestBody @Valid CreateOrderRequest request);
+
+    @Operation(summary = "주문조회 API")
+    ResponseEntity<OrderDetailResponse> getOrderDetail(@PathVariable Long orderId);
+
+}

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
@@ -1,6 +1,6 @@
 package com.emotionalcart.order.presentation.controller;
 
-import com.emotionalcart.order.application.CreateOrderService;
+import com.emotionalcart.order.application.service.CreateOrderService;
 import com.emotionalcart.order.application.service.OrderDetailService;
 import com.emotionalcart.order.domain.dto.CreatedOrder;
 import com.emotionalcart.order.domain.dto.OrderDetail;

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
@@ -7,25 +7,21 @@ import com.emotionalcart.order.domain.dto.OrderDetail;
 import com.emotionalcart.order.presentation.controller.request.CreateOrderRequest;
 import com.emotionalcart.order.presentation.controller.response.CreatedOrderResponse;
 import com.emotionalcart.order.presentation.controller.response.OrderDetailResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "order", description = "order API")
 @RestController
 @RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
-public class OrderController {
+public class OrderController implements OrderApiDocs {
 
     private final CreateOrderService createOrderService;
 
     private final OrderDetailService orderDetailService;
 
     @PostMapping
-    @Operation(summary = "create Order API")
     public ResponseEntity<CreatedOrderResponse> createOrder(@RequestBody @Valid CreateOrderRequest request) {
         CreatedOrder createdOrder = createOrderService.createOrder(request.mapToDomain());
         // 주문 생성
@@ -39,7 +35,6 @@ public class OrderController {
      * @return
      */
     @GetMapping("/{orderId}")
-    @Operation(summary = "get Order API")
     public ResponseEntity<OrderDetailResponse> getOrderDetail(@PathVariable Long orderId) {
         OrderDetail orderDetail = orderDetailService.getOrderDetail(orderId);
         return ResponseEntity.ok(OrderDetailResponse.from(orderDetail));

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
@@ -1,0 +1,35 @@
+package com.emotionalcart.order.presentation.controller;
+
+import com.emotionalcart.order.application.service.OrderStatisticsService;
+import com.emotionalcart.order.presentation.controller.response.SalesRankingResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "order", description = "order statistics API")
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderStatisticsController {
+
+    private final OrderStatisticsService orderStatisticsService;
+
+    /**
+     * 카테고리 별 판매량 많은 상품 조회
+     *
+     * @param categoryId 카테고리 식별자
+     * @param request    페이징
+     * @return
+     */
+    @GetMapping("/sales-ranking/{categoryId}")
+    public ResponseEntity<SalesRankingResponse> getProductRanking(@PathVariable Long categoryId, PageRequest request) {
+        return ResponseEntity.ok().body(SalesRankingResponse.from(orderStatisticsService.getProductRankingByCategoryId(categoryId,
+                                                                                                                       request)));
+    }
+
+}

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
@@ -2,7 +2,6 @@ package com.emotionalcart.order.presentation.controller;
 
 import com.emotionalcart.order.application.service.OrderStatisticsService;
 import com.emotionalcart.order.domain.dto.BestSellingProduct;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,11 +11,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "order", description = "order statistics API")
 @RestController
 @RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
-public class OrderStatisticsController {
+public class OrderStatisticsController implements OrderStatisticsDocs {
 
     private final OrderStatisticsService orderStatisticsService;
 
@@ -30,7 +28,7 @@ public class OrderStatisticsController {
     @GetMapping("/sales-ranking/{categoryId}")
     public ResponseEntity<Page<BestSellingProduct>> getProductRanking(@PathVariable Long categoryId, Pageable request) {
         return ResponseEntity.ok().body(orderStatisticsService.getProductRankingByCategoryId(categoryId,
-                                                                                             request));
+                request));
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
@@ -1,9 +1,10 @@
 package com.emotionalcart.order.presentation.controller;
 
 import com.emotionalcart.order.application.service.OrderStatisticsService;
-import com.emotionalcart.order.presentation.controller.response.SalesRankingResponse;
+import com.emotionalcart.order.domain.dto.BestSellingProduct;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,9 +28,9 @@ public class OrderStatisticsController {
      * @return
      */
     @GetMapping("/sales-ranking/{categoryId}")
-    public ResponseEntity<SalesRankingResponse> getProductRanking(@PathVariable Long categoryId, Pageable request) {
-        return ResponseEntity.ok().body(SalesRankingResponse.from(orderStatisticsService.getProductRankingByCategoryId(categoryId,
-                                                                                                                       request)));
+    public ResponseEntity<Page<BestSellingProduct>> getProductRanking(@PathVariable Long categoryId, Pageable request) {
+        return ResponseEntity.ok().body(orderStatisticsService.getProductRankingByCategoryId(categoryId,
+                                                                                             request));
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsController.java
@@ -4,7 +4,7 @@ import com.emotionalcart.order.application.service.OrderStatisticsService;
 import com.emotionalcart.order.presentation.controller.response.SalesRankingResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +27,7 @@ public class OrderStatisticsController {
      * @return
      */
     @GetMapping("/sales-ranking/{categoryId}")
-    public ResponseEntity<SalesRankingResponse> getProductRanking(@PathVariable Long categoryId, PageRequest request) {
+    public ResponseEntity<SalesRankingResponse> getProductRanking(@PathVariable Long categoryId, Pageable request) {
         return ResponseEntity.ok().body(SalesRankingResponse.from(orderStatisticsService.getProductRankingByCategoryId(categoryId,
                                                                                                                        request)));
     }

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsDocs.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderStatisticsDocs.java
@@ -1,0 +1,16 @@
+package com.emotionalcart.order.presentation.controller;
+
+import com.emotionalcart.order.domain.dto.BestSellingProduct;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "주문", description = "주문 통계 API")
+public interface OrderStatisticsDocs {
+
+    @Operation(summary = "카테고리 별 상품 판매량 많은 순 조회 API")
+    ResponseEntity<Page<BestSellingProduct>> getProductRanking(@PathVariable Long categoryId, Pageable request);
+}

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/request/CreateOrderRequest.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/request/CreateOrderRequest.java
@@ -60,7 +60,7 @@ public class CreateOrderRequest {
         }
         createOrder.createDeliveryInfo(delivery.getName(),
                                        delivery.getPhoneNumber(),
-                                       delivery.getZonecode(),
+                                       delivery.getZoneCode(),
                                        delivery.getAddress(),
                                        delivery.getDetailAddress(),
                                        delivery.getDeliveryMemo());
@@ -88,6 +88,12 @@ public class CreateOrderRequest {
          */
         @NotNull(message = "상품 옵션을 선택해주세요.")
         private Long productOptionId;
+
+        /**
+         * 카테고리 식별자
+         */
+        @NotNull(message = "상품 카테고리를 확인해주세요.")
+        private Long categoryId;
 
         /**
          * 상품명
@@ -132,7 +138,7 @@ public class CreateOrderRequest {
          * 우편번호
          */
         @NotNull(message = "우편번호를 입력해주세요.")
-        private String zonecode;
+        private String zoneCode;
         /**
          * 배송지 주소
          */

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/request/CreateOrderRequest.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/request/CreateOrderRequest.java
@@ -56,7 +56,12 @@ public class CreateOrderRequest {
                                           cardInfo.getCardOwnerName());
         }
         for (CreateOrderItemRequest orderItem : orderItems) {
-            createOrder.addItem(orderItem.productId, orderItem.productOptionId, orderItem.productName, orderItem.price, orderItem.quantity);
+            createOrder.addItem(orderItem.productId,
+                                orderItem.productOptionId,
+                                orderItem.categoryId,
+                                orderItem.productName,
+                                orderItem.price,
+                                orderItem.quantity);
         }
         createOrder.createDeliveryInfo(delivery.getName(),
                                        delivery.getPhoneNumber(),

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/response/SalesRankingResponse.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/response/SalesRankingResponse.java
@@ -1,0 +1,24 @@
+package com.emotionalcart.order.presentation.controller.response;
+
+import com.emotionalcart.order.domain.dto.BestSellingProduct;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SalesRankingResponse {
+
+    private List<BestSellingProduct> productList;
+
+    public SalesRankingResponse(List<BestSellingProduct> productList) {
+        this.productList = productList;
+    }
+
+    public static SalesRankingResponse from(List<BestSellingProduct> productRankingsByCategoryId) {
+        return new SalesRankingResponse(productRankingsByCategoryId);
+    }
+
+}

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/response/SalesRankingResponse.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/response/SalesRankingResponse.java
@@ -4,20 +4,19 @@ import com.emotionalcart.order.domain.dto.BestSellingProduct;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SalesRankingResponse {
 
-    private List<BestSellingProduct> productList;
+    private Page<BestSellingProduct> productList;
 
-    public SalesRankingResponse(List<BestSellingProduct> productList) {
+    public SalesRankingResponse(Page<BestSellingProduct> productList) {
         this.productList = productList;
     }
 
-    public static SalesRankingResponse from(List<BestSellingProduct> productRankingsByCategoryId) {
+    public static SalesRankingResponse from(Page<BestSellingProduct> productRankingsByCategoryId) {
         return new SalesRankingResponse(productRankingsByCategoryId);
     }
 

--- a/order/src/test/java/com/emotionalcart/order/application/service/CreateOrderServiceTest.java
+++ b/order/src/test/java/com/emotionalcart/order/application/service/CreateOrderServiceTest.java
@@ -1,6 +1,5 @@
 package com.emotionalcart.order.application.service;
 
-import com.emotionalcart.order.application.CreateOrderService;
 import com.emotionalcart.order.domain.dto.CreateOrder;
 import com.emotionalcart.order.domain.dto.CreatedOrder;
 import com.emotionalcart.order.domain.entity.Orders;

--- a/order/src/test/java/com/emotionalcart/order/application/service/CreateOrderServiceTest.java
+++ b/order/src/test/java/com/emotionalcart/order/application/service/CreateOrderServiceTest.java
@@ -7,6 +7,7 @@ import com.emotionalcart.order.domain.enums.PaymentMethod;
 import com.emotionalcart.order.infra.advice.exceptions.InvalidValueRequestException;
 import com.emotionalcart.order.infra.advice.exceptions.RequiredValueException;
 import com.emotionalcart.order.infra.order.OrderRepository;
+import com.emotionalcart.order.infra.order.OrderStatisticsRepository;
 import com.emotionalcart.order.infra.payment.PaymentService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,9 @@ class CreateOrderServiceTest {
     @Mock
     private PaymentService paymentService;
 
+    @Mock
+    private OrderStatisticsRepository orderStatisticsRepository;
+
     @InjectMocks
     private CreateOrderService createOrderService;
 
@@ -39,7 +43,7 @@ class CreateOrderServiceTest {
     void createOrder_success() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, 1L, "상품명", 1000L, 1);
+        createOrder.addItem(1L, 1L, 1L, "상품명", 1000L, 1);
         createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "123", "ddd");
         createOrder.createDeliveryInfo("이름", "010-1234-5678", "12345", "서울시 강남구", "상세주소", "비고");
         // when
@@ -77,7 +81,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_invalid_payment_method() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.TOSS).build();
-        createOrder.addItem(1L, 1L, "상품명", 1000L, 1);
+        createOrder.addItem(1L, 1L, 1L, "상품명", 1000L, 1);
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
 
         // when & then
@@ -92,7 +96,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_no_product_id() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(null, 1L, "상품명", 1000L, 1);
+        createOrder.addItem(null, 1L, 1L, "상품명", 1000L, 1);
         createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "123", "ddd");
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
 
@@ -108,7 +112,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_product_option_id() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, null, "상품명", 1000L, 1);
+        createOrder.addItem(1L, null, 1L, "상품명", 1000L, 1);
         createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "123", "ddd");
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then
@@ -122,7 +126,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_no_product_name() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, null, null, 1000L, 1);
+        createOrder.addItem(1L, null, 1L, null, 1000L, 1);
         createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "123", "ddd");
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then
@@ -136,7 +140,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_no_price_less_then_100() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, null, null, 99L, 1);
+        createOrder.addItem(1L, null, 1L, null, 99L, 1);
         createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "123", "ddd");
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then
@@ -150,7 +154,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_no_quantity_less_then_1() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, null, null, 1000L, 0);
+        createOrder.addItem(1L, null, 1L, null, 1000L, 0);
         createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "123", "ddd");
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then
@@ -164,7 +168,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_no_card_payment() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, 1L, "상품명", 1000L, 1);
+        createOrder.addItem(1L, 1L, 1L, "상품명", 1000L, 1);
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then
         assertThatThrownBy(() -> createOrderService.createOrder(createOrder))
@@ -177,7 +181,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_no_card_payment_validate_card_info() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, 1L, "상품명", 1000L, 1);
+        createOrder.addItem(1L, 1L, 1L, "상품명", 1000L, 1);
         createOrder.createNewCardInfo(null, null, null, null);
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then
@@ -196,7 +200,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_no_card_payment_validate_card_info_card_no_shorter_then_16() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, 1L, "상품명", 1000L, 1);
+        createOrder.addItem(1L, 1L, 1L, "상품명", 1000L, 1);
         createOrder.createNewCardInfo("12345678901234", "1234", "123", "ddd");
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then
@@ -222,7 +226,7 @@ class CreateOrderServiceTest {
     void createOrder_fail_cvc_not_numeric_and_len_is_3() {
         // given
         CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
-        createOrder.addItem(1L, 1L, "상품명", 1000L, 1);
+        createOrder.addItem(1L, 1L, 1L, "상품명", 1000L, 1);
         createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "abc", "ddd");
         createOrder.createDeliveryInfo(null, null, null, null, null, null);
         // when & then

--- a/order/src/test/java/com/emotionalcart/order/application/service/OrderStatisticsServiceTest.java
+++ b/order/src/test/java/com/emotionalcart/order/application/service/OrderStatisticsServiceTest.java
@@ -1,0 +1,73 @@
+package com.emotionalcart.order.application.service;
+
+import com.emotionalcart.order.domain.dto.CreateOrder;
+import com.emotionalcart.order.domain.dto.CreateOrderItem;
+import com.emotionalcart.order.domain.dto.CreatedOrder;
+import com.emotionalcart.order.domain.entity.OrderStatistics;
+import com.emotionalcart.order.domain.entity.Orders;
+import com.emotionalcart.order.domain.enums.PaymentMethod;
+import com.emotionalcart.order.infra.order.OrderRepository;
+import com.emotionalcart.order.infra.order.OrderStatisticsRepository;
+import com.emotionalcart.order.infra.payment.PaymentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderStatisticsServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @Mock
+    private OrderStatisticsRepository orderStatisticsRepository;
+
+    @InjectMocks
+    private CreateOrderService createOrderService;
+
+    @Test
+    @DisplayName("주문 만들기 성공 시 주문 통계 저장 테스트")
+    void createOrder_success() {
+        // Mock 데이터 설정
+        when(orderStatisticsRepository.findByProductIdAndCategoryId(2L, 2L))
+            .thenReturn(java.util.Optional.of(OrderStatistics.create(CreateOrderItem.builder().categoryId(2L).productId(2L).price(1000).quantity(
+                1).build())));
+        createOrder();
+        OrderStatistics orderStatistics = orderStatisticsRepository.findByProductIdAndCategoryId(2L, 2L).orElseThrow();
+        assertEquals(1L, orderStatistics.getTotalOrder());
+        assertEquals(1L, orderStatistics.getTotalQuantitySold());
+    }
+
+    private void createOrder() {
+        // given
+        CreateOrder createOrder = CreateOrder.builder().paymentMethod(PaymentMethod.CARD).build();
+        createOrder.addItem(2L, 2L, 2L, "상품명", 1000L, 1);
+        createOrder.createNewCardInfo("1234567890123456", getValidExpirationDate(), "123", "ddd");
+        createOrder.createDeliveryInfo("이름", "010-1234-5678", "12345", "서울시 강남구", "상세주소", "비고");
+        // when
+        when(orderRepository.save(any())).thenReturn(Orders.defaultOrder());
+        CreatedOrder order = createOrderService.createOrder(createOrder);
+    }
+
+    private String getValidExpirationDate() {
+        LocalDate now = LocalDate.now();
+        int month = now.getMonth().getValue() + 1;
+        String monthStr = month < 10 ? "0" + month : String.valueOf(month);
+        int year = now.getYear();
+        String yearStr = String.valueOf(year).substring(2);
+        return monthStr.concat("/").concat(yearStr);
+    }
+
+}

--- a/order/src/test/java/com/emotionalcart/order/presentation/controller/OrderStatisticsControllerTest.java
+++ b/order/src/test/java/com/emotionalcart/order/presentation/controller/OrderStatisticsControllerTest.java
@@ -1,0 +1,78 @@
+package com.emotionalcart.order.presentation.controller;
+
+import com.emotionalcart.order.application.service.OrderStatisticsService;
+import com.emotionalcart.order.domain.dto.BestSellingProduct;
+import com.emotionalcart.order.presentation.controller.response.SalesRankingResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class OrderStatisticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Mock
+    private OrderStatisticsService orderStatisticsService;
+
+    @InjectMocks
+    private OrderStatisticsController orderStatisticsController;
+
+    @BeforeEach
+    void setUp() {
+        // MockMvc를 컨트롤러와 함께 수동으로 설정
+        mockMvc = MockMvcBuilders.standaloneSetup(orderStatisticsController).build();
+    }
+
+    @Test
+    @DisplayName("카테고리별 판매량 많은 상품 조회 - 성공")
+    void getProductRanking_Success() throws Exception {
+        // Given (Mock 데이터 생성)
+        List<BestSellingProduct> productList = List.of(
+            new BestSellingProduct(1L, 100L),
+            new BestSellingProduct(2L, 80L)
+        );
+
+        Page<BestSellingProduct> productPage = new PageImpl<>(productList, PageRequest.of(0, 10), productList.size());
+        SalesRankingResponse response = SalesRankingResponse.from(productPage);
+
+        // orderStatisticsService Mock 설정
+        Mockito.when(orderStatisticsService.getProductRankingByCategoryId(eq(1L), any()))
+            .thenReturn(productPage);
+
+        // When & Then (API 호출 및 검증)
+        mockMvc.perform(get("/api/v1/orders/sales-ranking/1").param("page", "1").param("size", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk()) // HTTP 200 응답 확인
+            .andExpect(jsonPath("$.productList[0].productId").value(1L)) // 첫 번째 상품 ID 확인
+            .andExpect(jsonPath("$.productList[0].salesCount").value(100L)) // 첫 번째 판매량 확인
+            .andExpect(jsonPath("$.productList[1].productId").value(2L)) // 두 번째 상품 ID 확인
+            .andExpect(jsonPath("$.productList[1].salesCount").value(80L)) // 두 번째 판매량 확인
+            .andExpect(jsonPath("$.totalPages").value(1)) // 전체 페이지 수 확인
+            .andExpect(jsonPath("$.totalElements").value(2)) // 전체 요소 개수 확인
+            .andExpect(jsonPath("$.currentPage").value(0)) // 현재 페이지 번호 확인
+            .andExpect(jsonPath("$.size").value(10)); // 페이지 크기 확인
+    }
+
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* 주문 시 주문 통계 테이블 저장 프로세스 추가
* 카테고리 별 상품 최대 판매량 조회 API 추가

# 어떻게 해결했나요?

- 카테고리 별 상품 최대 판매량 조회 API
```
카테고리 별로 조회 시 상품 최대 판매량 순으로 조회할 수 있도록 개발하였습니다.
페이징 처리는 JPA를 사용했으며 해당 API도 Cursor-based Pagination이 필요하면 말씀해주세요
```

GET /api/v1/orders/sales-ranking/{categoryId}?page=0&size=10

- response

<table>
<tr>
 <th>productId</th>
 <th>categoryId</th>
 <th>totalOrder</th>
<th>totalQuantitySold</th>
</tr>
<tr>
<td>상품 식별자</td>
<td>카테고리 식별자(최하위 자식 카테고리)</td>
<td>총 주문 건 수</td>
<td>총 판매량</td>
</tr>
</table>

```json
{
    "totalPages": 0,
    "totalElements": 0,
    "first": true,
    "last": true,
    "size": 0,
    "content": [
     {
        "productId": 101,
        "categoryId": 5,
        "totalOrder": 3000,
        "totalQuantitySold": 15000
      },
     {
        "productId": 102,
        "categoryId": 5,
        "totalOrder": 250,
        "totalQuantitySold": 1200
      },
    ],
    "number": 0,
    "sort": {
      "empty": true,
      "sorted": true,
      "unsorted": true
    },
    "pageable": {
      "offset": 0,
      "sort": {
        "empty": true,
        "sorted": true,
        "unsorted": true
      },
      "paged": true,
      "pageNumber": 0,
      "pageSize": 0,
      "unpaged": true
    },
    "numberOfElements": 0,
    "empty": true
  
}
```

## Attachment

* 관련 업무 링크 추가!
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## PN 규칙

p1 : 적극적으로 고려해주세요 (Request changes)
리뷰를 받아들이거나 그럴수 없다면 토론을 해보자

p2 : 웬만하면 반영해 주세요 (Comment)
리뷰를 받아들이거나 그럴수 없다면 다음에 반영할 계획을 명시적으로(업무) 표현하자

p3 : 반영해도 좋고 넘어가도 좋습니다. (Approve)
의견에 대해 고민해보자

p4 : 그냥 사소한 의견입니다. (Approve)

# 주의점 및 기타 사항

* 
