### PR TITLE
[product] 가격 조회시 providerId 추가

### DIFF
--- a/product/src/main/java/com/emotionalcart/product/application/ProductService.java
+++ b/product/src/main/java/com/emotionalcart/product/application/ProductService.java
@@ -109,7 +109,7 @@ public class ProductService {
         // DTO 변환
         return ReadProducts.Response.toResponse(productPage, productOptions, categories, providers, productImages);
     }
-      
+
     public ReadProductDetails.Response getProductDetail(Long productId) {
 
         // 상품 정보
@@ -169,8 +169,9 @@ public class ProductService {
         for (ReadProductsValidate.Request request : requests) {
             validateProductExists(groupedProductDetails, request.getProductId());
             validateOptions(groupedProductDetails, request);
-            validateStock(groupedProductDetails, request);
         }
+
+        // TODO 재고 검증
     }
 
     private void validateProductExists(ProductDetails groupedProductDetails, Long productId) {
@@ -198,19 +199,6 @@ public class ProductService {
         }
     }
 
-    private void validateStock(ProductDetails groupedProductDetails, ReadProductsValidate.Request request) {
-        List<ProductDetail> productDetails = groupedProductDetails.getDetailsByProductId(request.getProductId());
-        Map<Long, Integer> optionDetailStockMap = productDetails.stream()
-                .collect(Collectors.toMap(ProductDetail::getProductOptionDetailId, ProductDetail::getQuantity));
-
-        for (ReadProductsValidate.Request.OptionRequest option : request.getProductOptions()) {
-            Integer availableStock = optionDetailStockMap.get(option.getProductOptionDetailId());
-            if (availableStock == null || option.getQuantity() > availableStock) {
-                throw new ProductException(ErrorCode.OUT_OF_STOCK);
-            }
-        }
-    }
-
     public List<ReadProductsPrice.Response> readProductsPrice(List<ReadProductsPrice.Request> requests) {
         Set<Long> productIds = requests.stream()
                 .map(ReadProductsPrice.Request::getProductId)
@@ -230,7 +218,15 @@ public class ProductService {
         return filteredDetails.stream()
                 .collect(Collectors.groupingBy(ProductDetail::getProductId))
                 .entrySet().stream()
-                .map(entry -> ReadProductsPrice.toResponse(entry.getKey(), entry.getValue()))
+                .map(entry -> {
+                    Long productId = entry.getKey();
+                    List<ProductDetail> details = entry.getValue();
+                    Long providerId = details.stream()
+                            .map(ProductDetail::getProviderId)
+                            .findFirst()
+                            .orElseThrow(() -> new ProductException(ErrorCode.NOT_FOUND_PRODUCT));
+                    return ReadProductsPrice.toResponse(productId, providerId, details);
+                })
                 .collect(Collectors.toList());
     }
 

--- a/product/src/main/java/com/emotionalcart/product/domain/dto/ProductDetail.java
+++ b/product/src/main/java/com/emotionalcart/product/domain/dto/ProductDetail.java
@@ -7,25 +7,25 @@ import lombok.Setter;
 @Setter
 public class ProductDetail {
     private Long productId;
+    private Long providerId;
     private Integer productPrice;
     private Long productOptionId;
     private Long productOptionDetailId;
     private Integer productAdditionalPrice;
-    private Integer quantity;
 
     public ProductDetail(Long productId,
+                         Long providerId,
                          Integer price,
                          Long productOptionId,
                          Long productOptionDetailId,
-                         Integer productAdditionalPrice,
-                         Integer quantity
+                         Integer productAdditionalPrice
     ) {
         this.productId = productId;
+        this.providerId = providerId;
         this.productPrice = price;
         this.productOptionId = productOptionId;
         this.productOptionDetailId = productOptionDetailId;
         this.productAdditionalPrice = productAdditionalPrice;
-        this.quantity = quantity;
     }
 }
 

--- a/product/src/main/java/com/emotionalcart/product/infrastructure/repository/QueryDslProductRepositoryImpl.java
+++ b/product/src/main/java/com/emotionalcart/product/infrastructure/repository/QueryDslProductRepositoryImpl.java
@@ -79,6 +79,7 @@ public class QueryDslProductRepositoryImpl implements QueryDslProductRepository 
                         Projections.constructor(
                                 ProductDetail.class,
                                 product.id,
+                                product.providerId,
                                 product.price,
                                 productOption.id,
                                 productOptionDetail.id,

--- a/product/src/main/java/com/emotionalcart/product/presentation/dto/ReadProductsPrice.java
+++ b/product/src/main/java/com/emotionalcart/product/presentation/dto/ReadProductsPrice.java
@@ -28,11 +28,13 @@ public class ReadProductsPrice {
     @Setter
     public static class Response {
         private Long productId;
+        private Long providerId;
         private Integer price;
         private List<ProductOption> productOptions;
 
-        private Response(Long productId, Integer price, List<ProductOption> productOptions) {
+        private Response(Long productId, Long providerId, Integer price, List<ProductOption> productOptions) {
             this.productId = productId;
+            this.providerId = providerId;
             this.price = price;
             this.productOptions = productOptions;
         }
@@ -60,12 +62,12 @@ public class ReadProductsPrice {
         }
     }
 
-    public static Response toResponse(Long productId, List<ProductDetail> productDetails) {
+    public static Response toResponse(Long productId, Long providerId, List<ProductDetail> productDetails) {
         Integer productPrice = productDetails.getFirst().getProductPrice();
         List<ReadProductsPrice.Response.ProductOption> productOptions = productDetails.stream()
                 .map(Response.ProductOption::fromProductDetail)
                 .toList();
 
-        return new Response(productId, productPrice, productOptions);
+        return new Response(productId, providerId, productPrice, productOptions);
     }
 }


### PR DESCRIPTION
+ 재고 조회 로직 제거 (재고 내용 반영되면 추후 추가)

# 해결하려는 문제가 무엇인가요?


<img width="500" alt="image" src="https://github.com/user-attachments/assets/6e77a54f-82c0-49a9-8488-87bbab4e6b5e" />


# 어떻게 해결했나요?

```
[
    {
        "productId": 11,
        "providerId": 1,
        "price": 1500000,
        "productOptions": [
            {
                "productOptionId": 19,
                "productOptionDetailId": 22,
                "additionalPrice": 0
            }
        ]
    },
    {
        "productId": 14,
        "providerId": 1,
        "price": 1500000,
        "productOptions": [
            {
                "productOptionId": 24,
                "productOptionDetailId": 26,
                "additionalPrice": 500000
            }
        ]
    }
]
```

## Attachment

* 관련 업무 링크 추가!
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## PN 규칙

p1 : 적극적으로 고려해주세요 (Request changes)
리뷰를 받아들이거나 그럴수 없다면 토론을 해보자

p2 : 웬만하면 반영해 주세요 (Comment)
리뷰를 받아들이거나 그럴수 없다면 다음에 반영할 계획을 명시적으로(업무) 표현하자

p3 : 반영해도 좋고 넘어가도 좋습니다. (Approve)
의견에 대해 고민해보자

p4 : 그냥 사소한 의견입니다. (Approve)

# 주의점 및 기타 사항

* 
