### PR TITLE
feat: 토큰 인증 프로세스 구현

### DIFF
--- a/auth/src/main/java/com/emotionalcart/auth/application/dto/MemberResponse.java
+++ b/auth/src/main/java/com/emotionalcart/auth/application/dto/MemberResponse.java
@@ -1,12 +1,18 @@
 package com.emotionalcart.auth.application.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberResponse {
+
     private Long userId;
-    private String role;
+    private List<String> roles;
     private String name;
+
 }

--- a/auth/src/main/java/com/emotionalcart/auth/domain/CustomOAuth2User.java
+++ b/auth/src/main/java/com/emotionalcart/auth/domain/CustomOAuth2User.java
@@ -3,6 +3,7 @@ package com.emotionalcart.auth.domain;
 import com.emotionalcart.auth.application.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.ArrayList;
@@ -20,21 +21,14 @@ public class CustomOAuth2User implements OAuth2User {
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("userId", memberResponse.getUserId());
         attributes.put("userName", memberResponse.getName());
-        attributes.put("role", memberResponse.getRole());
+        attributes.put("role", memberResponse.getRoles());
         return attributes;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();
-
-        collection.add(new GrantedAuthority() {
-            @Override
-            public String getAuthority() {
-                return memberResponse.getRole();
-            }
-        });
-
+        memberResponse.getRoles().stream().map(m -> new SimpleGrantedAuthority("ROLE_" + m)).forEach(collection::add);
         return collection;
     }
 
@@ -46,4 +40,5 @@ public class CustomOAuth2User implements OAuth2User {
     public String getName() {
         return memberResponse.getName();
     }
+
 }

--- a/auth/src/main/java/com/emotionalcart/auth/infrasturcture/member/http/MemberFeignClient.java
+++ b/auth/src/main/java/com/emotionalcart/auth/infrasturcture/member/http/MemberFeignClient.java
@@ -7,9 +7,10 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "member-service", url = "${member.find.feign-endpoint}", path = "/v1/members")
+@FeignClient(name = "member-service", url = "${member.find.feign-endpoint}", path = "/api/v1/members/auth")
 public interface MemberFeignClient {
 
     @PostMapping(value = "/find-or-create", consumes = MediaType.APPLICATION_JSON_VALUE)
     MemberResponse findOrCreate(@RequestBody MemberRequest request);
+
 }

--- a/auth/src/main/java/com/emotionalcart/auth/presentation/handler/CustomSuccessHandler.java
+++ b/auth/src/main/java/com/emotionalcart/auth/presentation/handler/CustomSuccessHandler.java
@@ -1,8 +1,8 @@
 package com.emotionalcart.auth.presentation.handler;
 
 import com.emotionalcart.auth.domain.CustomOAuth2User;
-import com.emotionalcart.core.config.jwt.JWTUtil;
-import jakarta.servlet.ServletException;
+import com.emotionalcart.common.jwt.JwtProperties;
+import com.emotionalcart.common.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,35 +11,34 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JWTUtil jwtUtil;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 
         // OAuth2User
-        CustomOAuth2User oauth2User = (CustomOAuth2User) authentication.getPrincipal();
+        CustomOAuth2User oauth2User = (CustomOAuth2User)authentication.getPrincipal();
         String username = oauth2User.getName();
         Long userId = oauth2User.getUserId();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-        GrantedAuthority auth = iterator.next();
-        String role = auth.getAuthority();
-
-        // JWT 생성 (1시간 유효시간)
-        String token = jwtUtil.createJwt(userId, username, role, 60 * 60L);
+        List<String> roles = authorities.stream().map(r -> "ROLE_" + r).toList();
+        String accessToken = jwtTokenProvider.createAccessToken(userId, username, roles);
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId, username, roles);
 
         // 응답 설정
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.setHeader("Authorization", "Bearer " + token);
+        response.setHeader("Access-Token", accessToken);
+        response.setHeader("Refresh-Token", refreshToken);
     }
+
 }

--- a/auth/src/main/java/com/emotionalcart/core/config/jwt/JWTFilter.java
+++ b/auth/src/main/java/com/emotionalcart/core/config/jwt/JWTFilter.java
@@ -1,7 +1,7 @@
 package com.emotionalcart.core.config.jwt;
 
-import com.emotionalcart.auth.domain.CustomOAuth2User;
 import com.emotionalcart.auth.application.dto.MemberResponse;
+import com.emotionalcart.auth.domain.CustomOAuth2User;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,7 +20,9 @@ public class JWTFilter extends OncePerRequestFilter {
     private final JWTUtil jwtUtil;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
+        ServletException,
+        IOException {
 
         // Authorization 헤더에서 토큰 추출
         String authorizationHeader = request.getHeader("Authorization");
@@ -46,7 +48,7 @@ public class JWTFilter extends OncePerRequestFilter {
         // 사용자 정보를 담아서 생성
         MemberResponse memberResponse = new MemberResponse();
         memberResponse.setName(userName);
-        memberResponse.setRole("COMMERCE_MEMBER");
+        // memberResponse.setRole("COMMERCE_MEMBER");
 
         // CustomOAuth2User 객체 생성
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(memberResponse);
@@ -60,4 +62,5 @@ public class JWTFilter extends OncePerRequestFilter {
         // 필터 체인 계속 진행
         filterChain.doFilter(request, response);
     }
+
 }

--- a/auth/src/main/java/com/emotionalcart/core/feature/Member.java
+++ b/auth/src/main/java/com/emotionalcart/core/feature/Member.java
@@ -9,6 +9,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Set;
+
+import static jakarta.persistence.FetchType.LAZY;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,7 +25,7 @@ public class Member extends BaseEntity {
     @NotNull
     private String socialId;
 
-//    @NotNull
+    //    @NotNull
     private String memberName;
 
     private String nickName;
@@ -36,13 +40,18 @@ public class Member extends BaseEntity {
     @NotNull
     private MemberState memberState;
 
+    @ElementCollection(fetch = LAZY)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "member_roles", joinColumns = @JoinColumn(name = "id"))
+    private Set<MemberRole> memberRoles;
+
     private Member(
-            String socialId,
-            String memberName,
-            String nickName,
-            String phone,
-            SocialType socialType,
-            MemberState memberState
+        String socialId,
+        String memberName,
+        String nickName,
+        String phone,
+        SocialType socialType,
+        MemberState memberState
     ) {
         this.socialId = socialId;
         this.memberName = memberName;
@@ -53,19 +62,20 @@ public class Member extends BaseEntity {
     }
 
     public static Member of(
-            String socialId,
-            String memberName,
-            String nickName,
-            String phone,
-            SocialType socialType,
-            MemberState memberState
+        String socialId,
+        String memberName,
+        String nickName,
+        String phone,
+        SocialType socialType,
+        MemberState memberState
     ) {
         return new Member(socialId,
-                memberName,
-                nickName,
-                phone,
-                socialType,
-                memberState
+                          memberName,
+                          nickName,
+                          phone,
+                          socialType,
+                          memberState
         );
     }
+
 }

--- a/auth/src/main/java/com/emotionalcart/core/feature/MemberRole.java
+++ b/auth/src/main/java/com/emotionalcart/core/feature/MemberRole.java
@@ -1,0 +1,6 @@
+package com.emotionalcart.core.feature;
+
+public enum MemberRole {
+    COMMERCE_MEMBER,
+    ADMIN_MEMBER
+}

--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -1,7 +1,9 @@
-
 spring:
   application:
     name: auth-service
+  profiles:
+    include:
+      - common
   main:
     :allow-bean-definition-overriding: true
   security:
@@ -39,7 +41,7 @@ spring:
             user-name-attribute: response
 
   datasource:
-    url: ${DATASOURCE_RUL:jdbc:mysql://localhost:3306/emotional_cart}
+    url: ${DATASOURCE_URL:jdbc:mysql://localhost:3306/emotional_cart}
     username: ${DATASOURCE_USERNAME:root}
     password: ${DATASOURCE_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -65,6 +67,10 @@ spring:
 logging:
   level:
     org.hibernate.SQL: DEBUG   # (선택) Hibernate 쿼리 로깅 활성화
+    feign:
+      client: DEBUG
+    com:
+      emotionalcart: DEBUG
 
 member:
   find:

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,6 +13,11 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("software.amazon.awssdk:s3:2.20.40")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    implementation("io.jsonwebtoken:jjwt-impl:0.12.3")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.12.3")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/common/src/main/java/com/emotionalcart/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/emotionalcart/common/exception/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.emotionalcart.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // 시스템 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-0001", "알 수 없는 오류가 발생했습니다."),
+
+    // 인증 && 인가
+    UNAUTHORIZED(HttpStatus.FORBIDDEN, "AUTH-0002", "인증 정보가 없습니다"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-0003", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-0004", "유효하지 않은 토큰입니다."),
+
+    // 유저
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String errorCode, String message) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/common/src/main/java/com/emotionalcart/common/exception/ErrorResponse.java
+++ b/common/src/main/java/com/emotionalcart/common/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.emotionalcart.common.exception;
+
+public record ErrorResponse(String errorCode, String errorMessage) {
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/CredentialInfo.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/CredentialInfo.java
@@ -1,0 +1,14 @@
+package com.emotionalcart.common.jwt;
+
+import lombok.Data;
+
+@Data
+public class CredentialInfo {
+
+    private Long credential;
+
+    public CredentialInfo(Long id) {
+        this.credential = id;
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/DefaultJwtAuthenticationProvider.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/DefaultJwtAuthenticationProvider.java
@@ -1,0 +1,58 @@
+package com.emotionalcart.common.jwt;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 로그인 시 인증 객체를 Authentication 에 담아주는 클래스
+ *
+ * @author seunggu.lee
+ * @see AuthenticationProvider#authenticate(Authentication)
+ */
+public abstract class DefaultJwtAuthenticationProvider implements AuthenticationProvider {
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken authenticationToken = (JwtAuthenticationToken)authentication;
+        return processUserAuthentication((JwtAuthentication)authenticationToken.getPrincipal());
+    }
+
+    private Authentication processUserAuthentication(JwtAuthentication principal) {
+        try {
+            Member account = getMember(principal.id());
+            CredentialInfo credentialInfo = new CredentialInfo(principal.id());
+            JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(
+                new JwtAuthentication(account.userId(), account.name()),
+                credentialInfo,
+                this.authorities(account.roles()));
+            authenticationToken.setDetails(account);
+            return authenticationToken;
+        } catch (IllegalArgumentException e) {
+            throw new BadCredentialsException(e.getMessage());
+        } catch (DataAccessException e) {
+            throw new AuthenticationServiceException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.isAssignableFrom(JwtAuthenticationToken.class);
+    }
+
+    protected abstract Member getMember(Long accountId);
+
+    private Collection<? extends GrantedAuthority> authorities(List<String> role) {
+        return role.stream().map(r -> new SimpleGrantedAuthority("ROLE_" + r)).collect(Collectors.toSet());
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/JwtAccessDeniedHandler.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.emotionalcart.common.jwt;
+
+import com.emotionalcart.common.exception.ErrorCode;
+import com.emotionalcart.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws
+        IOException {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.UNAUTHORIZED.getErrorCode(), ErrorCode.UNAUTHORIZED.getMessage());
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setHeader("content-type", "application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.getWriter().flush();
+        response.getWriter().close();
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/JwtAuthentication.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/JwtAuthentication.java
@@ -1,0 +1,5 @@
+package com.emotionalcart.common.jwt;
+
+public record JwtAuthentication(Long id, String name) {
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/JwtAuthenticationToken.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,50 @@
+package com.emotionalcart.common.jwt;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final transient Object principal;
+
+    private transient CredentialInfo credential;
+
+    public JwtAuthenticationToken(Object principal, CredentialInfo credential, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        super.setAuthenticated(true);
+        this.principal = principal;
+        this.credential = credential;
+    }
+
+    @Override
+    public CredentialInfo getCredentials() {
+        return credential;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        if (isAuthenticated) {
+            throw new IllegalArgumentException(
+                "Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead");
+        }
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        credential = null;
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/JwtAuthenticationTokenFilter.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/JwtAuthenticationTokenFilter.java
@@ -1,0 +1,97 @@
+package com.emotionalcart.common.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.nonNull;
+import static org.springframework.util.ObjectUtils.isEmpty;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationTokenFilter extends GenericFilterBean {
+
+    private final JwtProperties jwtProperties;
+
+    private final JwtTokenProvider tokenProvider;
+
+    private static final Pattern BEARER = Pattern.compile("^Bearer$", Pattern.CASE_INSENSITIVE);
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest)request;
+        HttpServletResponse res = (HttpServletResponse)response;
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            Optional<String> optionalAuthorizationToken = obtainAuthorizationToken(req, jwtProperties.getHeaderKey());
+            if (optionalAuthorizationToken.isPresent()) {
+                String authorizationToken = optionalAuthorizationToken.get();
+                try {
+                    setNewAuthenticationToken(req, authorizationToken);
+                } catch (Exception e) {
+                    log.error("JWT processing failed : {}", e.getMessage());
+                }
+            }
+        } else {
+            log.debug("SecurityContextHolder 에 security 토큰이 생성되지 않았습니다, 이미 저장된 인증정보 : '{}'",
+                      SecurityContextHolder.getContext().getAuthentication());
+        }
+        chain.doFilter(req, res);
+    }
+
+    private void setNewAuthenticationToken(HttpServletRequest req, String authorizationToken) {
+        Long id = tokenProvider.getId(authorizationToken);
+        String username = tokenProvider.getUsername(authorizationToken);
+
+        if (nonNull(id) && !isEmpty(username)) {
+            JwtAuthenticationToken authentication = new JwtAuthenticationToken(new JwtAuthentication(id, username), null,
+                                                                               this.authorities(authorizationToken));
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+    }
+
+    public Collection<? extends GrantedAuthority> authorities(String token) {
+        List<String> roles = tokenProvider.getRoles(token);
+        return roles.stream().map(r -> new SimpleGrantedAuthority("ROLE_" + r)).collect(Collectors.toSet());
+    }
+
+    public static Optional<String> obtainAuthorizationToken(HttpServletRequest req, String headerKey) {
+        Optional<String> optionalToken = Optional.ofNullable(req.getHeader(headerKey));
+        if (optionalToken.isPresent()) {
+            String token = optionalToken.get();
+            if (log.isDebugEnabled()) {
+                log.debug("JWT 인증 요청이 들어 왔습니다. 토큰 : {}", token);
+            }
+            token = URLDecoder.decode(token, StandardCharsets.UTF_8);
+            String[] parts = token.split(" ");
+            if (parts.length == 2) {
+                String scheme = parts[0];
+                String credentials = parts[1];
+                return BEARER.matcher(scheme).matches() ? Optional.ofNullable(credentials) : Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/JwtProperties.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.emotionalcart.common.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+
+    private String secretKey;
+
+    private String headerKey = "Authorization";
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/JwtTokenProvider.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,85 @@
+package com.emotionalcart.common.jwt;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Date;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        secretKey = new SecretKeySpec(jwtProperties.getSecretKey().getBytes(), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String createAccessToken(Long userId, String username, List<String> roles) {
+        long tokenValidationSecond = 1000L * 60 * 5;
+        return createToken(userId, username, roles, tokenValidationSecond);
+    }
+
+    public String createRefreshToken(Long userId, String username, List<String> roles) {
+        // 30분 동안 유효한 리프레시 토큰
+        long refreshTokenValidationSecond = 1000L * 60 * 30;
+        return createToken(userId, username, roles, refreshTokenValidationSecond);
+    }
+
+    public String createToken(Long userId, String username, List<String> roles, long expireTime) {
+        Claims claims = getClaims(userId, username, roles);
+        Date now = new Date();
+        return Jwts.builder().claims(claims)  // 데이터
+            .issuedAt(now)   // 토큰 발행 일자
+            .expiration(new Date(now.getTime() + expireTime))    // 만료 시간 추가
+            .signWith(secretKey)          // 암호화 알고리즘, secret 값 세팅
+            .compact();
+    }
+
+    private Claims getClaims(Long userId, String username, List<String> roles) {
+        return Jwts.claims()
+            .add("userId", userId)
+            .add("username", username)
+            .add("roles", roles)
+            .build();
+    }
+
+    public boolean validateToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(jwtToken);
+            return !claims.getPayload().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Claims getClaims(String jwtToken) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(jwtToken).getPayload();
+    }
+
+    public Long getId(String token) {
+        return getClaims(token).get("userId", Long.class);
+    }
+
+    public String getUsername(String token) {
+        return getClaims(token).get("username", String.class);
+    }
+
+    public List<String> getRoles(String token) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.convertValue(getClaims(token).get("roles"), new TypeReference<>() {
+        });
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/jwt/Member.java
+++ b/common/src/main/java/com/emotionalcart/common/jwt/Member.java
@@ -1,0 +1,10 @@
+package com.emotionalcart.common.jwt;
+
+import java.util.List;
+
+public record Member(
+    Long userId,
+    List<String> roles,
+    String name) {
+
+}

--- a/common/src/main/java/com/emotionalcart/common/security/AppProperties.java
+++ b/common/src/main/java/com/emotionalcart/common/security/AppProperties.java
@@ -1,0 +1,16 @@
+package com.emotionalcart.common.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties("app")
+public class AppProperties {
+
+    private List<String> allowDomains;
+    
+}

--- a/common/src/main/java/com/emotionalcart/common/security/CustomAuthenticationEntryPoint.java
+++ b/common/src/main/java/com/emotionalcart/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.emotionalcart.common.security;
+
+import com.emotionalcart.common.exception.ErrorCode;
+import com.emotionalcart.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws
+        IOException,
+        ServletException {
+        ErrorResponse errorResponse = new ErrorResponse(
+            ErrorCode.UNAUTHORIZED.getErrorCode(),
+            ErrorCode.UNAUTHORIZED.getMessage()
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/security/DefaultSecurityConfig.java
+++ b/common/src/main/java/com/emotionalcart/common/security/DefaultSecurityConfig.java
@@ -1,0 +1,88 @@
+package com.emotionalcart.common.security;
+
+import com.emotionalcart.common.jwt.JwtAccessDeniedHandler;
+import com.emotionalcart.common.jwt.JwtAuthenticationTokenFilter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.*;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class DefaultSecurityConfig {
+
+    private final AppProperties appProperties;
+    private final CustomAuthenticationEntryPoint entryPoint;
+    private final JwtAuthenticationTokenFilter jwtAuthenticationTokenFilter;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .cors(c -> c.configurationSource(corsConfigurationSource()))
+            .exceptionHandling(handleException())
+            .headers(handleExceptionHeader())
+            .sessionManagement(handleSessionPolicy())
+            .authorizeHttpRequests(request ->
+                                       getAuthorizedUrl(request).permitAll()
+                                           .anyRequest().authenticated())
+            .addFilterBefore(jwtAuthenticationTokenFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    private static Customizer<SessionManagementConfigurer<HttpSecurity>> handleSessionPolicy() {
+        return session -> session.sessionCreationPolicy(
+            SessionCreationPolicy.STATELESS);
+    }
+
+    private static Customizer<HeadersConfigurer<HttpSecurity>> handleExceptionHeader() {
+        return config -> config.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin);
+    }
+
+    private Customizer<ExceptionHandlingConfigurer<HttpSecurity>> handleException() {
+        return handle -> handle.accessDeniedHandler(jwtAccessDeniedHandler).authenticationEntryPoint(entryPoint);
+    }
+
+    protected AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizedUrl getAuthorizedUrl(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry request) {
+        return request.requestMatchers("/swagger-ui/**",
+                                       "/v3/api-docs/**",
+                                       "/swagger-resources/**",
+                                       "/actuator/**");
+    }
+
+    private CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        List<String> allowDomains = appProperties.getAllowDomains();
+        config.setAllowedOrigins(allowDomains);
+        config.setAllowedMethods(List.of("GET", "PUT", "DELETE", "POST", "PATCH", "OPTIONS", "HEAD"));
+        config.setExposedHeaders(List.of("Access-Control-Allow-Headers",
+                                         "Access-Token",
+                                         "Refresh-Token",
+                                         "Access-Control-Allow-Origin",
+                                         "strict-origin-when-cross-origin"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+}

--- a/common/src/main/java/com/emotionalcart/common/security/LoginAccountAuditorAware.java
+++ b/common/src/main/java/com/emotionalcart/common/security/LoginAccountAuditorAware.java
@@ -1,0 +1,32 @@
+package com.emotionalcart.common.security;
+
+import com.emotionalcart.common.jwt.JwtAuthentication;
+import com.emotionalcart.common.jwt.JwtAuthenticationToken;
+import jakarta.annotation.Nonnull;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class LoginAccountAuditorAware implements AuditorAware<Long> {
+
+    @Nonnull
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+        if (authentication instanceof AnonymousAuthenticationToken) {
+            return Optional.empty();
+        }
+        JwtAuthenticationToken authenticationToken = (JwtAuthenticationToken)authentication;
+        JwtAuthentication jwtAuthentication = (JwtAuthentication)authenticationToken.getPrincipal();
+        return Optional.of(jwtAuthentication.id());
+    }
+
+}

--- a/common/src/main/resources/application-common.yml
+++ b/common/src/main/resources/application-common.yml
@@ -1,0 +1,3 @@
+jwt:
+  secret-key: dlsjtjzmfdlzjajtmxlaghkdlxldgkqtlek
+  header-key: Authorization

--- a/member/src/main/java/com/emotionalcart/core/feature/Member.java
+++ b/member/src/main/java/com/emotionalcart/core/feature/Member.java
@@ -1,13 +1,18 @@
 package com.emotionalcart.core.feature;
 
 import com.emotionalcart.core.base.BaseEntity;
-import com.emotionalcart.core.feature.enums.SocialType;
+import com.emotionalcart.core.feature.enums.MemberRole;
 import com.emotionalcart.core.feature.enums.MemberState;
+import com.emotionalcart.core.feature.enums.SocialType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -36,13 +41,18 @@ public class Member extends BaseEntity {
     @NotNull
     private MemberState memberState;
 
+    @ElementCollection(fetch = LAZY)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "member_roles", joinColumns = @JoinColumn(name = "id"))
+    private final Set<MemberRole> memberRoles = Set.of(MemberRole.COMMERCE_MEMBER);
+
     private Member(
-            String socialId,
-            String userName,
-            String nickName,
-            String phone,
-            SocialType socialType,
-            MemberState memberState
+        String socialId,
+        String userName,
+        String nickName,
+        String phone,
+        SocialType socialType,
+        MemberState memberState
     ) {
         this.socialId = socialId;
         this.userName = userName;
@@ -53,17 +63,18 @@ public class Member extends BaseEntity {
     }
 
     public static Member of(
-            String socialId,
-            String userName,
-            SocialType socialType
+        String socialId,
+        String userName,
+        SocialType socialType
     ) {
         return new Member(
-                socialId,
-                userName,
-                null,
-                null,
-                socialType,
-                MemberState.ACTIVE
+            socialId,
+            userName,
+            null,
+            null,
+            socialType,
+            MemberState.ACTIVE
         );
     }
+
 }

--- a/member/src/main/java/com/emotionalcart/core/feature/enums/MemberRole.java
+++ b/member/src/main/java/com/emotionalcart/core/feature/enums/MemberRole.java
@@ -1,0 +1,6 @@
+package com.emotionalcart.core.feature.enums;
+
+public enum MemberRole {
+    COMMERCE_MEMBER,
+    ADMIN_MEMBER
+}

--- a/member/src/main/java/com/emotionalcart/member/application/MemberService.java
+++ b/member/src/main/java/com/emotionalcart/member/application/MemberService.java
@@ -1,8 +1,8 @@
 package com.emotionalcart.member.application;
 
 import com.emotionalcart.core.feature.Member;
-import com.emotionalcart.member.presentation.dto.MemberRequest;
 import com.emotionalcart.member.domain.MemberDataProvider;
+import com.emotionalcart.member.presentation.dto.MemberRequest;
 import com.emotionalcart.member.presentation.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,9 +19,10 @@ public class MemberService {
         Member member = memberDataProvider.findOrCreate(request.getSocialId(), request.getName(), request.getSocialType());
 
         return new MemberResponse(
-                member.getId(),
-                "COMMERCE_MEMBER",
-                member.getUserName()
+            member.getId(),
+            member.getMemberRoles().stream().map(Enum::name).toList(),
+            member.getUserName()
         );
     }
+
 }

--- a/member/src/main/java/com/emotionalcart/member/presentation/MemberController.java
+++ b/member/src/main/java/com/emotionalcart/member/presentation/MemberController.java
@@ -4,18 +4,25 @@ import com.emotionalcart.member.application.MemberService;
 import com.emotionalcart.member.presentation.dto.MemberRequest;
 import com.emotionalcart.member.presentation.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@RestController
-@RequestMapping("/v1/members")
+@Slf4j @RestController
+@RequestMapping("/api/v1/members/auth")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/find-or-create")
-    public ResponseEntity<MemberResponse>findOrCreate(@RequestBody MemberRequest request) {
+    @PostMapping(value = "/find-or-create", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<MemberResponse> findOrCreate(@RequestBody MemberRequest request) {
+        log.error("MemberController.findOrCreate request: {}", request);
         return ResponseEntity.ok(memberService.findOrCreate(request));
     }
+
 }

--- a/member/src/main/java/com/emotionalcart/member/presentation/dto/MemberResponse.java
+++ b/member/src/main/java/com/emotionalcart/member/presentation/dto/MemberResponse.java
@@ -4,11 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberResponse {
+
     private Long userId;
-    private String role;
+    private List<String> roles;
     private String name;
+
 }

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -2,14 +2,18 @@ spring:
   application:
     name: member-service
   datasource:
-    url: ${DATASOURCE_RUL:jdbc:mysql://localhost:3306/emotional_cart}
+    url: ${DATASOURCE_URL:jdbc:mysql://localhost:3306/emotional_cart}
     username: ${DATASOURCE_USERNAME:root}
     password: ${DATASOURCE_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
+  profiles:
+    active: default
+    group:
+      default:
+        - common
   jpa:
     hibernate:
-      ddl-auto: update  # (옵션: create, update, validate, none. 개발 시 `update` 추천)
+      ddl-auto: none  # (옵션: create, update, validate, none. 개발 시 `update` 추천)
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
@@ -25,6 +29,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: DEBUG   # (선택) Hibernate 쿼리 로깅 활성화
+    org.springframework: DEBUG
 server:
   port: 8081
 

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: order-service
+  profiles:
+    include:
+      - common
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DATASOURCE_URL:jdbc:mysql://localhost:3306/emotional_cart}?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -7,7 +7,9 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
-
+  profiles:
+    include:
+      - common
   datasource:
     url: ${DATASOURCE_URL}
     username: ${DATASOURCE_USERNAME}

--- a/stock/src/main/java/com/emotionalcart/stock/infra/SecurityConfig.java
+++ b/stock/src/main/java/com/emotionalcart/stock/infra/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.emotionalcart.core.config;
+package com.emotionalcart.stock.infra;
 
 import com.emotionalcart.common.jwt.JwtAccessDeniedHandler;
 import com.emotionalcart.common.jwt.JwtAuthenticationTokenFilter;
@@ -6,8 +6,6 @@ import com.emotionalcart.common.security.AppProperties;
 import com.emotionalcart.common.security.CustomAuthenticationEntryPoint;
 import com.emotionalcart.common.security.DefaultSecurityConfig;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 
 @Configuration
 public class SecurityConfig extends DefaultSecurityConfig {
@@ -17,12 +15,6 @@ public class SecurityConfig extends DefaultSecurityConfig {
                           JwtAuthenticationTokenFilter jwtAuthenticationTokenFilter,
                           JwtAccessDeniedHandler jwtAccessDeniedHandler) {
         super(appProperties, entryPoint, jwtAuthenticationTokenFilter, jwtAccessDeniedHandler);
-    }
-
-    @Override
-    protected AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizedUrl getAuthorizedUrl(
-        AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry request) {
-        return request.requestMatchers("/api/v1/members/auth/**", "/error");
     }
 
 }

--- a/stock/src/main/resources/application.yml
+++ b/stock/src/main/resources/application.yml
@@ -1,9 +1,12 @@
 spring:
   application:
     name: stock-service
+  profiles:
+    include:
+      - common
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DATASOURCE_RUL:jdbc:mysql://localhost:3306/emotional_cart}
+    url: ${DATASOURCE_URL:jdbc:mysql://localhost:3306/emotional_cart}
     username: ${DATASOURCE_USERNAME:root}
     password: ${DATASOURCE_PASSWORD:1234}
   jpa:


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* 로그인 이후 access-token, refresh-token 발급, 각 요청 마다 header의 토큰을 꺼내서 검증후 security context-holder에 값 넣어주기

# 어떻게 해결했나요?

* common 모듈에 security-starter 디펜던시를 추가하고 전역 설정.
* 각 모듈에서 `DefaultSecurityConfig` 를 상속받고 `@Configuration` 등록 후 사용
* `getPermissionUrl` 메서드를 오버라이드 해서 각 모듈에 맞는 허용 url을 등록
* `LoginAccountAuditorAware` 를 통해 데이터베이스에 현 로그인 사용자 등록하고 싶을때 `@CreatedBy` 어노테이션으로 자동 등록

## Attachment

* 관련 업무 링크 추가!
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## PN 규칙

p1 : 적극적으로 고려해주세요 (Request changes)
리뷰를 받아들이거나 그럴수 없다면 토론을 해보자

p2 : 웬만하면 반영해 주세요 (Comment)
리뷰를 받아들이거나 그럴수 없다면 다음에 반영할 계획을 명시적으로(업무) 표현하자

p3 : 반영해도 좋고 넘어가도 좋습니다. (Approve)
의견에 대해 고민해보자

p4 : 그냥 사소한 의견입니다. (Approve)

# 주의점 및 기타 사항

* 
