### PR TITLE
feat: 상품 기본 조회 가능하도록 열기

### DIFF
--- a/product/src/main/java/com/emotionalcart/core/config/SecurityConfig.java
+++ b/product/src/main/java/com/emotionalcart/core/config/SecurityConfig.java
@@ -19,10 +19,16 @@ public class SecurityConfig extends DefaultSecurityConfig {
 
     @Override
     protected String[] getPermissionUrl() {
-        return new String[]{"/swagger-ui/**",
-                "/v3/api-docs/**",
-                "/swagger-resources/**",
-                "/actuator/**",
-                "/api/v1/products/**",};
+        return new String[] {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/actuator/**",
+            "/api/v1/banners/**",
+            "/api/v1/categories/**",
+            "/api/v1/products/*",
+            "/api/v1/products/{productId}/reviews",
+            "/api/v1/products/search"
+        };
     }
 }

--- a/product/src/main/java/com/emotionalcart/core/feature/review/Review.java
+++ b/product/src/main/java/com/emotionalcart/core/feature/review/Review.java
@@ -3,10 +3,10 @@ package com.emotionalcart.core.feature.review;
 import com.emotionalcart.core.base.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
 
 @Entity
 @Table
@@ -19,6 +19,7 @@ public class Review extends BaseEntity {
     private Long id;
 
     @NotNull
+    @CreatedBy
     private Long userId;
 
     @NotNull
@@ -36,7 +37,6 @@ public class Review extends BaseEntity {
     private String content;
 
     private Review(
-        Long userId,
         Long productId,
         String productName,
         String productOptionId,
@@ -44,7 +44,6 @@ public class Review extends BaseEntity {
         Integer rating,
         String content
     ) {
-        this.userId = userId;
         this.productId = productId;
         this.productName = productName;
         this.productOptionId = productOptionId;
@@ -54,7 +53,6 @@ public class Review extends BaseEntity {
     }
 
     public static Review of(
-        Long userId,
         Long productId,
         String productName,
         String productOptionId,
@@ -63,7 +61,6 @@ public class Review extends BaseEntity {
         String content
     ) {
         return new Review(
-            userId,
             productId,
             productName,
             productOptionId,

--- a/product/src/main/java/com/emotionalcart/core/feature/review/Review.java
+++ b/product/src/main/java/com/emotionalcart/core/feature/review/Review.java
@@ -19,7 +19,7 @@ public class Review extends BaseEntity {
     private Long id;
 
     @NotNull
-    private String userId;
+    private Long userId;
 
     @NotNull
     private Long productId;
@@ -36,13 +36,13 @@ public class Review extends BaseEntity {
     private String content;
 
     private Review(
-            String userId,
-            Long productId,
-            String productName,
-            String productOptionId,
-            String productOptionName,
-            Integer rating,
-            String content
+        Long userId,
+        Long productId,
+        String productName,
+        String productOptionId,
+        String productOptionName,
+        Integer rating,
+        String content
     ) {
         this.userId = userId;
         this.productId = productId;
@@ -54,21 +54,23 @@ public class Review extends BaseEntity {
     }
 
     public static Review of(
-            Long productId,
-            String productName,
-            String productOptionId,
-            String productOptionName,
-            Integer rating,
-            String content
+        Long userId,
+        Long productId,
+        String productName,
+        String productOptionId,
+        String productOptionName,
+        Integer rating,
+        String content
     ) {
         return new Review(
-                "userId", // TODO 회원가입 적용 이후 반영
-                productId,
-                productName,
-                productOptionId,
-                productOptionName,
-                rating,
-                content
+            userId,
+            productId,
+            productName,
+            productOptionId,
+            productOptionName,
+            rating,
+            content
         );
     }
+
 }

--- a/product/src/main/java/com/emotionalcart/product/application/ProductService.java
+++ b/product/src/main/java/com/emotionalcart/product/application/ProductService.java
@@ -67,7 +67,7 @@ public class ProductService {
         Product product = productDataProvider.findProduct(productId);
         productDataProvider.findProductReview(productId, jwt.id());
         // TODO 유저 구매내역 확인
-        Review review = request.toReviewEntity(jwt.id(), productId);
+        Review review = request.toReviewEntity(productId);
         productDataProvider.saveProductReview(review);
 
         List<ReviewImage> reviewImages = uploadAndCreateReviewImages(review.getId(), request.getReviewImages());

--- a/product/src/main/java/com/emotionalcart/product/application/ProductService.java
+++ b/product/src/main/java/com/emotionalcart/product/application/ProductService.java
@@ -1,5 +1,6 @@
 package com.emotionalcart.product.application;
 
+import com.emotionalcart.common.security.LoginAccountAuditorAware;
 import com.emotionalcart.core.exception.ErrorCode;
 import com.emotionalcart.core.exception.ProductException;
 import com.emotionalcart.core.feature.category.Category;
@@ -36,10 +37,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductService {
+
     private final ProductDataProvider productDataProvider;
     private final CategoryDataProvider categoryDataProvider;
     private final ProviderDataProvider providerDataProvider;
     private final S3Utils s3Utils;
+    private final LoginAccountAuditorAware loginAccountAuditorAware;
 
     public Page<ReadProductReviews.Response> readProductReviews(@NotNull Long productId,
                                                                 ReadProductReviews.Request request) {
@@ -58,8 +61,12 @@ public class ProductService {
 
     @Transactional
     public CreateProductReviewResponse createProductReview(@NotNull Long productId, CreateProductReviewRequest request) {
+        String userId = loginAccountAuditorAware.getCurrentAuditor()
+            .orElseThrow(() -> new ProductException(ErrorCode.UNAUTHORIZE_ERROR))
+            .toString();
+
         Product product = productDataProvider.findProduct(productId);
-        productDataProvider.findProductReview(productId, "userId123"); // TODO 실제 userId 반영
+        productDataProvider.findProductReview(productId, userId);
         // TODO 유저 구매내역 확인
         Review review = request.toReviewEntity(productId);
         productDataProvider.saveProductReview(review);
@@ -83,12 +90,12 @@ public class ProductService {
             try {
                 String fileUrl = s3Utils.uploadFile(S3Constants.REVIEW_DIRECTORY, reviewId.toString(), file);
                 return ReviewImage.of(
-                        reviewId,
-                        file.getOriginalFilename(),
-                        fileUrl,
-                        file.getContentType(),
-                        file.getSize(),
-                        files.indexOf(file) + 1
+                    reviewId,
+                    file.getOriginalFilename(),
+                    fileUrl,
+                    file.getContentType(),
+                    file.getSize(),
+                    files.indexOf(file) + 1
                 );
             } catch (Exception e) {
                 throw new ProductException(ErrorCode.S3_UPLOAD_FAILED);
@@ -123,45 +130,46 @@ public class ProductService {
         for (ProductOption productOption : productOptions) {
             // 상품 옵션 상세 정보
             List<ProductOptionDetail> productOptionDetails = productDataProvider
-                    .findAllProductOptionDetailsByProductOptionId(productOption.getId());
+                .findAllProductOptionDetailsByProductOptionId(productOption.getId());
 
             List<ReadProductOptionDetails.Response> productOptionDetailResponses = new ArrayList<>();
 
             for (ProductOptionDetail productOptionDetail : productOptionDetails) {
-                ReadProductOptionDetails.Response productOptionDetailResponse = ReadProductOptionDetails.Response.toResponse(productOptionDetail);
+                ReadProductOptionDetails.Response productOptionDetailResponse =
+                    ReadProductOptionDetails.Response.toResponse(productOptionDetail);
                 productOptionDetailResponses.add(productOptionDetailResponse);
             }
 
             ReadProductOptions.Response productOptionResponse = ReadProductOptions.Response
-                    .toResponse(productOption, productOptionDetailResponses);
+                .toResponse(productOption, productOptionDetailResponses);
 
             productOptionsResponses.add(productOptionResponse);
         }
 
         // 리뷰 평균 평점 및 리뷰 개수
         ReadProductReviewStatistic.Response reviewStatistic = ReadProductReviewStatistic.Response
-                .toResponse(productDataProvider.findReviewStatistic(productId));
+            .toResponse(productDataProvider.findReviewStatistic(productId));
 
         // 카테고리 정보
         ReadProductCategories.Response categoryResponse = ReadProductCategories.Response
-                .toResponse(categoryDataProvider.findCategoryById(product.getCategoryId()));
+            .toResponse(categoryDataProvider.findCategoryById(product.getCategoryId()));
 
         // 공급자 정보
         ReadProviders.Response providerResponse = ReadProviders.Response
-                .toResponse(providerDataProvider.findProviderById(product.getProviderId()));
+            .toResponse(providerDataProvider.findProviderById(product.getProviderId()));
 
         // 상품 이미지
         List<ReadProductImages.Response> productImages = ReadProductImages.Response
-                .toResponse(productDataProvider.findProductImages(productId));
+            .toResponse(productDataProvider.findProductImages(productId));
 
         return ReadProductDetails.Response.toResponse(product, productOptionsResponses, categoryResponse,
-                providerResponse, reviewStatistic, productImages);
+                                                      providerResponse, reviewStatistic, productImages);
     }
 
     public void readProductsValidate(List<ReadProductsValidate.Request> requests) {
         Set<Long> productIds = requests.stream()
-                .map(ReadProductsValidate.Request::getProductId)
-                .collect(Collectors.toSet());
+            .map(ReadProductsValidate.Request::getProductId)
+            .collect(Collectors.toSet());
 
         List<ProductDetail> productDetails = productDataProvider.findAllProductDetail(productIds);
         ProductDetails groupedProductDetails = ProductDetails.from(productDetails);
@@ -185,11 +193,11 @@ public class ProductService {
         Set<Long> allOptionIds = groupedProductDetails.getAllOptionIds(productId);
         Set<Long> allOptionDetailIds = groupedProductDetails.getAllOptionDetailIds(productId);
         Set<Long> selectedOptionIds = request.getProductOptions().stream()
-                .map(ReadProductsValidate.Request.OptionRequest::getProductOptionId)
-                .collect(Collectors.toSet());
+            .map(ReadProductsValidate.Request.OptionRequest::getProductOptionId)
+            .collect(Collectors.toSet());
         Set<Long> selectedOptionDetailIds = request.getProductOptions().stream()
-                .map(ReadProductsValidate.Request.OptionRequest::getProductOptionDetailId)
-                .collect(Collectors.toSet());
+            .map(ReadProductsValidate.Request.OptionRequest::getProductOptionDetailId)
+            .collect(Collectors.toSet());
 
         if (!allOptionIds.containsAll(selectedOptionIds)) {
             throw new ProductException(ErrorCode.NOT_FOUND_PRODUCT_OPTION);
@@ -201,14 +209,14 @@ public class ProductService {
 
     public List<ReadProductsPrice.Response> readProductsPrice(List<ReadProductsPrice.Request> requests) {
         Set<Long> productIds = requests.stream()
-                .map(ReadProductsPrice.Request::getProductId)
-                .collect(Collectors.toSet());
+            .map(ReadProductsPrice.Request::getProductId)
+            .collect(Collectors.toSet());
 
         List<ProductDetail> productDetails = productDataProvider.findAllProductDetail(productIds);
         Set<Long> productOptionDetailIds = requests.stream()
-                .flatMap(request -> request.getProductOptions().stream())
-                .map(ReadProductsPrice.Request.OptionRequest::getProductOptionDetailId)
-                .collect(Collectors.toSet());
+            .flatMap(request -> request.getProductOptions().stream())
+            .map(ReadProductsPrice.Request.OptionRequest::getProductOptionDetailId)
+            .collect(Collectors.toSet());
 
         ProductDetails groupedProductDetails = ProductDetails.from(productDetails);
         List<ProductDetail> filteredDetails = groupedProductDetails.filterByOptionDetailIds(productOptionDetailIds);
@@ -216,18 +224,18 @@ public class ProductService {
         validateOptions(groupedProductDetails, requests);
 
         return filteredDetails.stream()
-                .collect(Collectors.groupingBy(ProductDetail::getProductId))
-                .entrySet().stream()
-                .map(entry -> {
-                    Long productId = entry.getKey();
-                    List<ProductDetail> details = entry.getValue();
-                    Long providerId = details.stream()
-                            .map(ProductDetail::getProviderId)
-                            .findFirst()
-                            .orElseThrow(() -> new ProductException(ErrorCode.NOT_FOUND_PRODUCT));
-                    return ReadProductsPrice.toResponse(productId, providerId, details);
-                })
-                .collect(Collectors.toList());
+            .collect(Collectors.groupingBy(ProductDetail::getProductId))
+            .entrySet().stream()
+            .map(entry -> {
+                Long productId = entry.getKey();
+                List<ProductDetail> details = entry.getValue();
+                Long providerId = details.stream()
+                    .map(ProductDetail::getProviderId)
+                    .findFirst()
+                    .orElseThrow(() -> new ProductException(ErrorCode.NOT_FOUND_PRODUCT));
+                return ReadProductsPrice.toResponse(productId, providerId, details);
+            })
+            .collect(Collectors.toList());
     }
 
     private void validateOptions(ProductDetails groupedProductDetails, List<ReadProductsPrice.Request> requests) {
@@ -240,9 +248,9 @@ public class ProductService {
             }
 
             Map<Long, Set<Long>> optionToDetailMap = productDetails.stream()
-                    .collect(Collectors.groupingBy(
-                            ProductDetail::getProductOptionId,
-                            Collectors.mapping(ProductDetail::getProductOptionDetailId, Collectors.toSet())));
+                .collect(Collectors.groupingBy(
+                    ProductDetail::getProductOptionId,
+                    Collectors.mapping(ProductDetail::getProductOptionDetailId, Collectors.toSet())));
 
             for (ReadProductsPrice.Request.OptionRequest option : request.getProductOptions()) {
                 Set<Long> validDetailIds = optionToDetailMap.get(option.getProductOptionId());
@@ -252,4 +260,5 @@ public class ProductService {
             }
         }
     }
+
 }

--- a/product/src/main/java/com/emotionalcart/product/application/ProductService.java
+++ b/product/src/main/java/com/emotionalcart/product/application/ProductService.java
@@ -1,5 +1,6 @@
 package com.emotionalcart.product.application;
 
+import com.emotionalcart.common.jwt.JwtAuthentication;
 import com.emotionalcart.common.security.LoginAccountAuditorAware;
 import com.emotionalcart.core.exception.ErrorCode;
 import com.emotionalcart.core.exception.ProductException;
@@ -60,15 +61,13 @@ public class ProductService {
     }
 
     @Transactional
-    public CreateProductReviewResponse createProductReview(@NotNull Long productId, CreateProductReviewRequest request) {
-        String userId = loginAccountAuditorAware.getCurrentAuditor()
-            .orElseThrow(() -> new ProductException(ErrorCode.UNAUTHORIZE_ERROR))
-            .toString();
-
+    public CreateProductReviewResponse createProductReview(JwtAuthentication jwt,
+                                                           @NotNull Long productId,
+                                                           CreateProductReviewRequest request) {
         Product product = productDataProvider.findProduct(productId);
-        productDataProvider.findProductReview(productId, userId);
+        productDataProvider.findProductReview(productId, jwt.id());
         // TODO 유저 구매내역 확인
-        Review review = request.toReviewEntity(productId);
+        Review review = request.toReviewEntity(jwt.id(), productId);
         productDataProvider.saveProductReview(review);
 
         List<ReviewImage> reviewImages = uploadAndCreateReviewImages(review.getId(), request.getReviewImages());

--- a/product/src/main/java/com/emotionalcart/product/domain/ProductDataProvider.java
+++ b/product/src/main/java/com/emotionalcart/product/domain/ProductDataProvider.java
@@ -45,7 +45,7 @@ public class ProductDataProvider {
         return reviewImageRepository.findAllByReviewIdInAndIsDeletedIsFalse(reviewIds);
     }
 
-    public void findProductReview(Long productId, String userId) {
+    public void findProductReview(Long productId, Long userId) {
         reviewRepository.findByProductIdAndUserIdAndIsDeletedIsFalse(productId, userId)
                 .ifPresent(review -> {
                     throw new ProductException(ErrorCode.DUPLICATE_REVIEW);

--- a/product/src/main/java/com/emotionalcart/product/infrastructure/repository/ReviewRepository.java
+++ b/product/src/main/java/com/emotionalcart/product/infrastructure/repository/ReviewRepository.java
@@ -12,5 +12,5 @@ import java.util.Optional;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findAllByProductIdAndIsDeletedIsFalse(@NotNull Long productId, PageRequest pageRequest);
-    Optional<Review> findByProductIdAndUserIdAndIsDeletedIsFalse(Long productId, String userId);
+    Optional<Review> findByProductIdAndUserIdAndIsDeletedIsFalse(Long productId, Long userId);
 }

--- a/product/src/main/java/com/emotionalcart/product/presentation/ProductController.java
+++ b/product/src/main/java/com/emotionalcart/product/presentation/ProductController.java
@@ -1,5 +1,6 @@
 package com.emotionalcart.product.presentation;
 
+import com.emotionalcart.common.jwt.JwtAuthentication;
 import com.emotionalcart.product.application.ProductService;
 import com.emotionalcart.product.presentation.dto.*;
 import com.emotionalcart.product.presentation.dto.request.CreateProductReviewRequest;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,14 +20,15 @@ import java.util.List;
 @RequestMapping("/api/v1/products")
 @RequiredArgsConstructor
 public class ProductController implements ProductControllerDocs {
+
     private final ProductService productService;
 
     // 상품 리뷰 조회
     @Override
     @GetMapping("/{productId}/reviews")
     public ResponseEntity<Page<ReadProductReviews.Response>> readProductReviews(
-            @PathVariable Long productId,
-            ReadProductReviews.Request request) {
+        @PathVariable Long productId,
+        ReadProductReviews.Request request) {
         return ResponseEntity.ok(productService.readProductReviews(productId, request));
     }
 
@@ -33,9 +36,10 @@ public class ProductController implements ProductControllerDocs {
     @Override
     @PostMapping(value = "/{productId}/review", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CreateProductReviewResponse> createProductReview(
-            @PathVariable Long productId,
-            @ModelAttribute @Valid CreateProductReviewRequest request) {
-        return ResponseEntity.ok(productService.createProductReview(productId, request));
+        @AuthenticationPrincipal JwtAuthentication jwt,
+        @PathVariable Long productId,
+        @ModelAttribute @Valid CreateProductReviewRequest request) {
+        return ResponseEntity.ok(productService.createProductReview(jwt, productId, request));
     }
 
     // 상품 상세 조회
@@ -46,20 +50,21 @@ public class ProductController implements ProductControllerDocs {
 
     @Override
     public ResponseEntity<Page<ReadProducts.Response>> readProducts(
-            ReadProducts.Request request) {
+        ReadProducts.Request request) {
         return ResponseEntity.ok(productService.readProducts(request));
     }
 
     @Override
     public ResponseEntity<Void> readProductsValidate(
-            @RequestBody @Valid List<ReadProductsValidate.Request> requests) {
+        @RequestBody @Valid List<ReadProductsValidate.Request> requests) {
         productService.readProductsValidate(requests);
         return ResponseEntity.ok().build();
     }
 
     @Override
     public ResponseEntity<List<ReadProductsPrice.Response>> readProductsPrice(
-            @RequestBody @Valid List<ReadProductsPrice.Request> requests) {
+        @RequestBody @Valid List<ReadProductsPrice.Request> requests) {
         return ResponseEntity.ok(productService.readProductsPrice(requests));
     }
+
 }

--- a/product/src/main/java/com/emotionalcart/product/presentation/ProductControllerDocs.java
+++ b/product/src/main/java/com/emotionalcart/product/presentation/ProductControllerDocs.java
@@ -1,5 +1,6 @@
 package com.emotionalcart.product.presentation;
 
+import com.emotionalcart.common.jwt.JwtAuthentication;
 import com.emotionalcart.product.presentation.dto.*;
 import com.emotionalcart.product.presentation.dto.request.CreateProductReviewRequest;
 import com.emotionalcart.product.presentation.dto.response.CreateProductReviewResponse;
@@ -8,11 +9,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,294 +22,268 @@ import java.util.List;
 @Tag(name = "상품 API", description = "상품 관련 API")
 public interface ProductControllerDocs {
 
-    @Operation(summary = "상품 리뷰 조회", description = "특정 상품의 리뷰 목록을 페이징하여 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "상품 리뷰 조회 성공", content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = ReadProductReviews.Response.class))),
-            @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음",
-                    content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                        "errorCode": "PRODUCT-006",
-                                        "errorMessage": "상품을 찾을 수 없습니다."
-                                    }
-                                    """
-                            )
-                    ))
-    })
-    ResponseEntity<Page<ReadProductReviews.Response>> readProductReviews(
-            @PathVariable Long productId,
-            ReadProductReviews.Request request);
+    // 상품 리뷰 조회
+    @GetMapping("/{productId}/reviews") ResponseEntity<Page<ReadProductReviews.Response>> readProductReviews(
+        @PathVariable Long productId,
+        ReadProductReviews.Request request);
 
-    @Operation(summary = "상품 리뷰 등록", description = "특정 상품의 리뷰를 등록합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "리뷰 등록 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = CreateProductReviewResponse.class),
-                            examples = @ExampleObject(name = "리뷰 등록 성공",
-                                    value = "{ \"reviewId\": 1 }"))),
-            @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
-                    {
-                        "errorCode": "PRODUCT-0006",
-                        "errorMessage": "해당 상품을 찾을 수 없습니다."
-                    }
-                    """)))
-    })
-    ResponseEntity<CreateProductReviewResponse> createProductReview(
-            @PathVariable Long productId,
-            @Valid @ModelAttribute CreateProductReviewRequest createProductReviewRequest
-    );
+    // 상품 리뷰 등록
+    @PostMapping(value = "/{productId}/review", consumes = MediaType.MULTIPART_FORM_DATA_VALUE) ResponseEntity<CreateProductReviewResponse> createProductReview(
+        @AuthenticationPrincipal JwtAuthentication jwt,
+        @PathVariable Long productId,
+        @ModelAttribute @Valid CreateProductReviewRequest request);
 
     // 상품 상세 조회
     @GetMapping("/{productId}")
     @Operation(summary = "상품 상세 조회", description = "특정 상품의 상세 정보를 조회합니다.", responses = {
-            @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReadProductDetails.Response.class), examples = @ExampleObject(value = """
+        @ApiResponse(responseCode = "200", description = "상품 상세 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReadProductDetails.Response.class), examples = @ExampleObject(value = """
+            {
+                "id": 1,
+                "name": "핸드폰",
+                "description": "핸드폰 설명",
+                "price": 1500000,
+                "category": {
+                    "id": 1,
+                    "name": "전자제품",
+                    "parentCategoryId": null,
+                    "subCategories": [
+                        {
+                            "id": 4,
+                            "name": "노트북",
+                            "parentCategoryId": 1,
+                            "subCategories": []
+                        },
+                        {
+                            "id": 5,
+                            "name": "스마트폰",
+                            "parentCategoryId": 1,
+                            "subCategories": []
+                        },
+                        {
+                            "id": 6,
+                            "name": "태블릿",
+                            "parentCategoryId": 1,
+                            "subCategories": []
+                        }
+                    ]
+                },
+                "provider": {
+                    "id": 1,
+                    "name": "TechProvider",
+                    "description": "최고의 기술 제품 제공 업체"
+                },
+                "options": [
                     {
-                        "id": 1,
-                        "name": "핸드폰",
-                        "description": "핸드폰 설명",
-                        "price": 1500000,
-                        "category": {
-                            "id": 1,
-                            "name": "전자제품",
-                            "parentCategoryId": null,
-                            "subCategories": [
-                                {
-                                    "id": 4,
-                                    "name": "노트북",
-                                    "parentCategoryId": 1,
-                                    "subCategories": []
-                                },
-                                {
-                                    "id": 5,
-                                    "name": "스마트폰",
-                                    "parentCategoryId": 1,
-                                    "subCategories": []
-                                },
-                                {
-                                    "id": 6,
-                                    "name": "태블릿",
-                                    "parentCategoryId": 1,
-                                    "subCategories": []
-                                }
-                            ]
-                        },
-                        "provider": {
-                            "id": 1,
-                            "name": "TechProvider",
-                            "description": "최고의 기술 제품 제공 업체"
-                        },
-                        "options": [
+                        "id": 5,
+                        "name": "색상",
+                        "optionDetails": [
                             {
-                                "id": 5,
-                                "name": "색상",
-                                "optionDetails": [
-                                    {
-                                        "id": 8,
-                                        "value": "검정",
-                                        "quantity": 50,
-                                        "order": 1,
-                                        "additionalPrice": 0
-                                    },
-                                    {
-                                        "id": 12,
-                                        "value": "은색",
-                                        "quantity": 30,
-                                        "order": 2,
-                                        "additionalPrice": 10000
-                                    }
-                                ]
-                            }
-                        ],
-                        "reviewStatistic": {
-                            "averageRating": 4.5,
-                            "reviewCount": 120
-                        },
-                        "images": [
-                            {
-                                "id": 1,
-                                "fileOrder": 1,
-                                "url": "https://example.com/images/main.png",
-                                "type": "MAIN"
+                                "id": 8,
+                                "value": "검정",
+                                "quantity": 50,
+                                "order": 1,
+                                "additionalPrice": 0
                             },
                             {
-                                "id": 5,
-                                "fileOrder": 1,
-                                "url": "https://example.com/images/datail.png",
-                                "type": "DETAIL"
+                                "id": 12,
+                                "value": "은색",
+                                "quantity": 30,
+                                "order": 2,
+                                "additionalPrice": 10000
                             }
                         ]
                     }
-                    """))),
-            @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                ],
+                "reviewStatistic": {
+                    "averageRating": 4.5,
+                    "reviewCount": 120
+                },
+                "images": [
                     {
-                        "errorCode": "PRODUCT-0006",
-                        "errorMessage": "해당 상품을 찾을 수 없습니다."
+                        "id": 1,
+                        "fileOrder": 1,
+                        "url": "https://example.com/images/main.png",
+                        "type": "MAIN"
+                    },
+                    {
+                        "id": 5,
+                        "fileOrder": 1,
+                        "url": "https://example.com/images/datail.png",
+                        "type": "DETAIL"
                     }
-                    """)))
+                ]
+            }
+            """))),
+        @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+            {
+                "errorCode": "PRODUCT-0006",
+                "errorMessage": "해당 상품을 찾을 수 없습니다."
+            }
+            """)))
     })
     ResponseEntity<ReadProductDetails.Response> getProductDetail(@PathVariable Long productId);
 
     // 상품 검증
     @PostMapping("/validate")
     ResponseEntity<Void> readProductsValidate(
-            @RequestBody @Valid List<ReadProductsValidate.Request> requests);
+        @RequestBody @Valid List<ReadProductsValidate.Request> requests);
 
     // 상품 가격 조회
     @PostMapping("/price")
     ResponseEntity<List<ReadProductsPrice.Response>> readProductsPrice(
-            @RequestBody @Valid List<ReadProductsPrice.Request> requests);
+        @RequestBody @Valid List<ReadProductsPrice.Request> requests);
 
     //상품 목록 조회
     @GetMapping("/search")
     @Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.", responses = {
-            @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReadProducts.Response.class), examples = @ExampleObject(value = """
+        @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReadProducts.Response.class), examples = @ExampleObject(value = """
+            {
+                "content": [
                     {
-                        "content": [
-                            {
-                                  "productId": 3,
-                                  "name": "러닝화",
-                                  "description": "가볍고 편안한 러닝화",
-                                  "price": 25000,
-                                  "category": {
-                                      "id": 2,
-                                      "name": "패션",
-                                      "parentCategoryId": null,
-                                      "subCategories": [
-                                          {
-                                              "id": 7,
-                                              "name": "남성 의류",
-                                              "parentCategoryId": 2,
-                                              "subCategories": []
-                                          },
-                                          {
-                                              "id": 8,
-                                              "name": "여성 의류",
-                                              "parentCategoryId": 2,
-                                              "subCategories": []
-                                          }
-                                      ]
+                          "productId": 3,
+                          "name": "러닝화",
+                          "description": "가볍고 편안한 러닝화",
+                          "price": 25000,
+                          "category": {
+                              "id": 2,
+                              "name": "패션",
+                              "parentCategoryId": null,
+                              "subCategories": [
+                                  {
+                                      "id": 7,
+                                      "name": "남성 의류",
+                                      "parentCategoryId": 2,
+                                      "subCategories": []
                                   },
-                                  "provider": {
-                                      "id": 2,
-                                      "name": "FashionWorld",
-                                      "description": "모든 사람을 위한 스타일리시한 의류"
-                                  },
-                                  "options": [
+                                  {
+                                      "id": 8,
+                                      "name": "여성 의류",
+                                      "parentCategoryId": 2,
+                                      "subCategories": []
+                                  }
+                              ]
+                          },
+                          "provider": {
+                              "id": 2,
+                              "name": "FashionWorld",
+                              "description": "모든 사람을 위한 스타일리시한 의류"
+                          },
+                          "options": [
+                              {
+                                  "id": 7,
+                                  "name": "사이즈",
+                                  "optionDetails": [
+                                      {
+                                          "id": 5,
+                                          "value": "Small",
+                                          "quantity": 100,
+                                          "order": 1,
+                                          "additionalPrice": 0
+                                      },
+                                      {
+                                          "id": 6,
+                                          "value": "Large",
+                                          "quantity": 50,
+                                          "order": 2,
+                                          "additionalPrice": 0
+                                      },
                                       {
                                           "id": 7,
-                                          "name": "사이즈",
-                                          "optionDetails": [
-                                              {
-                                                  "id": 5,
-                                                  "value": "Small",
-                                                  "quantity": 100,
-                                                  "order": 1,
-                                                  "additionalPrice": 0
-                                              },
-                                              {
-                                                  "id": 6,
-                                                  "value": "Large",
-                                                  "quantity": 50,
-                                                  "order": 2,
-                                                  "additionalPrice": 0
-                                              },
-                                              {
-                                                  "id": 7,
-                                                  "value": "Medium",
-                                                  "quantity": 50,
-                                                  "order": 3,
-                                                  "additionalPrice": 0
-                                              }
-                                          ]
-                                      }
-                                  ],
-                                  "rating": 4.2,
-                                  "images": [
-                                      {
-                                          "id": 3,
-                                          "fileOrder": 1,
-                                          "url": "https://example.com/images/main.png",
-                                          "type": "MAIN"
+                                          "value": "Medium",
+                                          "quantity": 50,
+                                          "order": 3,
+                                          "additionalPrice": 0
                                       }
                                   ]
-                              },
-                            {
-                                 "productId": 2,
-                                 "name": "스마트폰 X",
-                                 "description": "최신 기능이 탑재된 스마트폰",
-                                 "price": 200000,
-                                 "category": {
-                                     "id": 1,
-                                     "name": "전자제품",
-                                     "parentCategoryId": null,
-                                     "subCategories": [
-                                         {
-                                             "id": 4,
-                                             "name": "노트북",
-                                             "parentCategoryId": 1,
-                                             "subCategories": []
-                                         },
-                                         {
-                                             "id": 5,
-                                             "name": "스마트폰",
-                                             "parentCategoryId": 1,
-                                             "subCategories": []
-                                         },
-                                         {
-                                             "id": 6,
-                                             "name": "태블릿",
-                                             "parentCategoryId": 1,
-                                             "subCategories": []
-                                         }
-                                     ]
+                              }
+                          ],
+                          "rating": 4.2,
+                          "images": [
+                              {
+                                  "id": 3,
+                                  "fileOrder": 1,
+                                  "url": "https://example.com/images/main.png",
+                                  "type": "MAIN"
+                              }
+                          ]
+                      },
+                    {
+                         "productId": 2,
+                         "name": "스마트폰 X",
+                         "description": "최신 기능이 탑재된 스마트폰",
+                         "price": 200000,
+                         "category": {
+                             "id": 1,
+                             "name": "전자제품",
+                             "parentCategoryId": null,
+                             "subCategories": [
+                                 {
+                                     "id": 4,
+                                     "name": "노트북",
+                                     "parentCategoryId": 1,
+                                     "subCategories": []
                                  },
-                                 "provider": {
-                                     "id": 1,
-                                     "name": "TechProvider",
-                                     "description": "최고의 기술 제품 제공 업체"
+                                 {
+                                     "id": 5,
+                                     "name": "스마트폰",
+                                     "parentCategoryId": 1,
+                                     "subCategories": []
                                  },
-                                 "options": [
+                                 {
+                                     "id": 6,
+                                     "name": "태블릿",
+                                     "parentCategoryId": 1,
+                                     "subCategories": []
+                                 }
+                             ]
+                         },
+                         "provider": {
+                             "id": 1,
+                             "name": "TechProvider",
+                             "description": "최고의 기술 제품 제공 업체"
+                         },
+                         "options": [
+                             {
+                                 "id": 6,
+                                 "name": "저장 용량",
+                                 "optionDetails": [
                                      {
-                                         "id": 6,
-                                         "name": "저장 용량",
-                                         "optionDetails": [
-                                             {
-                                                 "id": 10,
-                                                 "value": "256GB",
-                                                 "quantity": 20,
-                                                 "order": 3,
-                                                 "additionalPrice": 20000
-                                             },
-                                             {
-                                                 "id": 11,
-                                                 "value": "512GB",
-                                                 "quantity": 10,
-                                                 "order": 4,
-                                                 "additionalPrice": 40000
-                                             }
-                                         ]
-                                     }
-                                 ],
-                                 "rating": 4.8,
-                                 "images": [
+                                         "id": 10,
+                                         "value": "256GB",
+                                         "quantity": 20,
+                                         "order": 3,
+                                         "additionalPrice": 20000
+                                     },
                                      {
-                                         "id": 2,
-                                         "fileOrder": 1,
-                                         "url": "https://example.com/images/main.png",
-                                         "type": "MAIN"
+                                         "id": 11,
+                                         "value": "512GB",
+                                         "quantity": 10,
+                                         "order": 4,
+                                         "additionalPrice": 40000
                                      }
                                  ]
                              }
-                        ],
-                        "page": {
-                            "size": 10,
-                            "number": 0,
-                            "totalElements": 3,
-                            "totalPages": 1
-                        }
-                    }
-                    """)))
+                         ],
+                         "rating": 4.8,
+                         "images": [
+                             {
+                                 "id": 2,
+                                 "fileOrder": 1,
+                                 "url": "https://example.com/images/main.png",
+                                 "type": "MAIN"
+                             }
+                         ]
+                     }
+                ],
+                "page": {
+                    "size": 10,
+                    "number": 0,
+                    "totalElements": 3,
+                    "totalPages": 1
+                }
+            }
+            """)))
     })
     ResponseEntity<Page<ReadProducts.Response>> readProducts(ReadProducts.Request request);
+
 }

--- a/product/src/main/java/com/emotionalcart/product/presentation/dto/request/CreateProductReviewRequest.java
+++ b/product/src/main/java/com/emotionalcart/product/presentation/dto/request/CreateProductReviewRequest.java
@@ -24,9 +24,8 @@ public class CreateProductReviewRequest {
     private String content;
     private List<MultipartFile> reviewImages;
 
-    public Review toReviewEntity(Long userId, Long productId) {
+    public Review toReviewEntity(Long productId) {
         return Review.of(
-            userId,
             productId,
             productName,
             productOptionId,

--- a/product/src/main/java/com/emotionalcart/product/presentation/dto/request/CreateProductReviewRequest.java
+++ b/product/src/main/java/com/emotionalcart/product/presentation/dto/request/CreateProductReviewRequest.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Getter
 @Setter
 public class CreateProductReviewRequest {
+
     private String productName;
     private String productOptionId;
     private String productOptionName;
@@ -23,14 +24,16 @@ public class CreateProductReviewRequest {
     private String content;
     private List<MultipartFile> reviewImages;
 
-    public Review toReviewEntity(Long productId) {
+    public Review toReviewEntity(Long userId, Long productId) {
         return Review.of(
-                productId,
-                productName,
-                productOptionId,
-                productOptionName,
-                rating,
-                content
+            userId,
+            productId,
+            productName,
+            productOptionId,
+            productOptionName,
+            rating,
+            content
         );
     }
+
 }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* 상품 기본 조회는 인증 없이도 가능하도록 수정
* /api/v1/products/validate, /api/v1/products/price 는 적용이 안됩니다.
  * (버그바운티 이후 어드민으로 위치 옮기는게 좋을 것 같습니다.)

# 어떻게 해결했나요?

*

## Attachment

* 관련 업무 링크 추가!
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## PN 규칙

p1 : 적극적으로 고려해주세요 (Request changes)
리뷰를 받아들이거나 그럴수 없다면 토론을 해보자

p2 : 웬만하면 반영해 주세요 (Comment)
리뷰를 받아들이거나 그럴수 없다면 다음에 반영할 계획을 명시적으로(업무) 표현하자

p3 : 반영해도 좋고 넘어가도 좋습니다. (Approve)
의견에 대해 고민해보자

p4 : 그냥 사소한 의견입니다. (Approve)

# 주의점 및 기타 사항

* @AuthenticationPrincipal JwtAuthentication jwt 사용하는게 맞는지..?
* 
