### PR TITLE
feat: 토큰 쿠키에 저장하도록 수정

### DIFF
--- a/auth/src/main/java/com/emotionalcart/auth/presentation/handler/CustomSuccessHandler.java
+++ b/auth/src/main/java/com/emotionalcart/auth/presentation/handler/CustomSuccessHandler.java
@@ -3,6 +3,7 @@ package com.emotionalcart.auth.presentation.handler;
 import com.emotionalcart.auth.domain.CustomOAuth2User;
 import com.emotionalcart.common.jwt.JwtProperties;
 import com.emotionalcart.common.jwt.JwtTokenProvider;
+import com.emotionalcart.core.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -26,9 +27,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtProperties jwtProperties;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws
+        IOException {
         HttpSession session = request.getSession();
-        String redirectUri = (String) session.getAttribute("redirect_uri");
+        String redirectUri = (String)session.getAttribute("redirect_uri");
         session.removeAttribute("redirect_uri"); // 사용 후 제거
 
         log.info("Redirect URI: {}", redirectUri);
@@ -38,7 +40,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         }
 
         // OAuth2User
-        CustomOAuth2User oauth2User = (CustomOAuth2User) authentication.getPrincipal();
+        CustomOAuth2User oauth2User = (CustomOAuth2User)authentication.getPrincipal();
         String username = oauth2User.getName();
         Long userId = oauth2User.getUserId();
 
@@ -48,10 +50,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String refreshToken = jwtTokenProvider.createRefreshToken(userId, username, roles);
 
         // 응답 설정
+        CookieUtil.addCookie(response, "Access-Token", accessToken, 5 * 60);
+        CookieUtil.addCookie(response, "Refresh-Token", refreshToken, 30 * 60);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.setHeader("Access-Token", accessToken);
-        response.setHeader("Refresh-Token", refreshToken);
         response.sendRedirect(redirectUri);
     }
+
 }

--- a/auth/src/main/java/com/emotionalcart/core/util/CookieUtil.java
+++ b/auth/src/main/java/com/emotionalcart/core/util/CookieUtil.java
@@ -1,0 +1,26 @@
+package com.emotionalcart.core.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);  // JavaScript에서 접근 불가능 (보안 강화)
+        cookie.setSecure(true);   // HTTPS에서만 전송
+        cookie.setPath("/");       // 모든 경로에서 쿠키 전송
+        cookie.setMaxAge(maxAge);  // 쿠키 유효 시간 설정 (초 단위)
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(cookie);
+    }
+
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* 302 리디렉션 되는 경우 프론트에서는 header를 읽을 수 없다고 합니다.

# 어떻게 해결했나요?
* header 대신 cookie에 토큰을 전달하는 방식으로 변경했습니다. 
* 쿼리 파라미터로 전달하는건 보안상 가장 좋지 않다고 하여 보류했습니다...
<img width="774" alt="image" src="https://github.com/user-attachments/assets/27505719-9330-42dd-813f-0cee8dae633d" />

## Attachment

* 관련 업무 링크 추가!
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## PN 규칙

p1 : 적극적으로 고려해주세요 (Request changes)
리뷰를 받아들이거나 그럴수 없다면 토론을 해보자

p2 : 웬만하면 반영해 주세요 (Comment)
리뷰를 받아들이거나 그럴수 없다면 다음에 반영할 계획을 명시적으로(업무) 표현하자

p3 : 반영해도 좋고 넘어가도 좋습니다. (Approve)
의견에 대해 고민해보자

p4 : 그냥 사소한 의견입니다. (Approve)

# 주의점 및 기타 사항

* 좋은 방법 있으면 알려주세요..
