### PR TITLE
feat : 사용자 기반 주문 검증 기능 추가

### DIFF
--- a/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
+++ b/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 @Slf4j
@@ -52,9 +51,10 @@ public class OrderDetailService {
         return new PageImpl<>(userOrders, request, orderList.getTotalElements());
     }
 
-    public Boolean validateOrderByMember(Long id, Long orderId) {
-        Optional<Orders> byOrderIdAndUserId = orderRepository.findByIdAndOrderMemberId(orderId, id);
-        return byOrderIdAndUserId.isPresent();
+    public Boolean validateOrderByMember(Long userId, Long orderId) {
+        return orderRepository.findByIdAndOrderMemberId(orderId, userId)
+            .map(Orders::isCompleted)
+            .orElse(false);
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
+++ b/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 @Slf4j
@@ -39,7 +40,7 @@ public class OrderDetailService {
      */
     public Page<UserOrder> getOrderListByUserId(Long userId, Pageable request) {
         PageRequest pageRequest = PageRequest.of(request.getPageNumber(), request.getPageSize(), Sort.by(Sort.Order.desc("orderAt")));
-        Page<Orders> orderList = orderRepository.findByUserId(userId, pageRequest);
+        Page<Orders> orderList = orderRepository.findByOrderMemberId(userId, pageRequest);
         List<List<ProductDetail>> productDetailsByOrders =
             orderList.stream().map(order -> order.getOrderItems().stream().map(orderItem -> productService.getProductDetail(orderItem.getProductId())).toList()).toList();
 
@@ -49,6 +50,11 @@ public class OrderDetailService {
 
         // 최종적으로 Page<UserOrder> 반환
         return new PageImpl<>(userOrders, request, orderList.getTotalElements());
+    }
+
+    public Boolean validateOrderByMember(Long id, Long orderId) {
+        Optional<Orders> byOrderIdAndUserId = orderRepository.findByIdAndOrderMemberId(orderId, id);
+        return byOrderIdAndUserId.isPresent();
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/domain/entity/Orders.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/entity/Orders.java
@@ -142,4 +142,8 @@ public class Orders extends BaseEntity {
         return totalPrice.getAmount();
     }
 
+    public Boolean isCompleted() {
+        return this.getStatus() == OrderStatus.DELIVERED;
+    }
+
 }

--- a/order/src/main/java/com/emotionalcart/order/domain/entity/Orders.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/entity/Orders.java
@@ -76,12 +76,6 @@ public class Orders extends BaseEntity {
     private String shipmentId;
 
     /**
-     * 사용자 아이디
-     */
-    @CreatedBy
-    private Long userId;
-
-    /**
      * 주문 항목 목록
      */
     @OneToMany(mappedBy = "orders", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -109,13 +103,7 @@ public class Orders extends BaseEntity {
             Money.sum(createOrder.getOrderItemsPriceAndQuantity());
         orders.createOrderItems(createOrder.getOrderItems());
         orders.createOrderRecipient(createOrder.getDeliveryInfo());
-        orders.createUser();
         return orders;
-    }
-
-    // TODO : 주문 생성 시 사용자 정보를 가져오는 로직 추가
-    private void createUser() {
-        this.userId = 0L;
     }
 
     private void createOrderRecipient(@NotNull(message = "배송 정보를 입력해주세요.") DeliveryInfo deliveryInfo) {

--- a/order/src/main/java/com/emotionalcart/order/infra/order/OrderRepository.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/order/OrderRepository.java
@@ -5,8 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrderRepository extends JpaRepository<Orders, Long> {
 
-    Page<Orders> findByUserId(Long userId, Pageable pageable);
+    Page<Orders> findByOrderMemberId(Long userId, Pageable pageable);
+
+    Optional<Orders> findByIdAndOrderMemberId(Long orderId, Long id);
 
 }

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
@@ -55,4 +55,13 @@ public class OrderController implements OrderApiDocs {
         return ResponseEntity.ok().body(userOrders.map(UserOrderResponse::from));
     }
 
+    /**
+     * 사용자 주문 검증
+     */
+    @GetMapping("/users/validate/{orderId}")
+    public ResponseEntity<Boolean> validateOrderByMember(@AuthenticationPrincipal JwtAuthentication jwt, @PathVariable Long orderId) {
+        Boolean isExistOrder = orderDetailService.validateOrderByMember(jwt.id(), orderId);
+        return ResponseEntity.ok().body(isExistOrder);
+    }
+
 }


### PR DESCRIPTION
: 리뷰를 작성하기 전에 해당 주문이 로그인한 사용자(userId, 토큰)의 주문인지 검증

# 해결하려는 문제가 무엇인가요?

: 사용자 ID(userId)와 주문 ID(orderId)를 검증
: JWT 토큰을 기반으로 사용자의 주문인지 확인
: 배송 완료(DELIVERED) 상태일 때만 true 반환

: 주문 테이블에 사용자 아이디가 두개 들어가고있어서 userId 컬럼은 제거 했습니다.

해당 주문이 배송완료 상태일때만 리뷰가 등록 가능하도록 추가 조건을 넣었습니다 🤔

* return 값의 경우 Boolean으로 내려옵니다.
* GET /api/v1/orders/users/validate/{orderId}
![image](https://github.com/user-attachments/assets/d9d84ff9-28fb-4d1f-bec9-55fb7399c53c)


