### PR TITLE
feat : 사용자 주문 내역 조회 시 응답 값 추가

### DIFF
--- a/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
+++ b/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
@@ -2,6 +2,7 @@ package com.emotionalcart.order.application;
 
 import com.emotionalcart.order.domain.dto.OrderDetail;
 import com.emotionalcart.order.domain.dto.UserOrder;
+import com.emotionalcart.order.domain.entity.OrderItemOption;
 import com.emotionalcart.order.domain.entity.Orders;
 import com.emotionalcart.order.infra.advice.exceptions.InvalidValueRequestException;
 import com.emotionalcart.order.infra.order.OrderRepository;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Slf4j
@@ -41,13 +44,25 @@ public class OrderDetailService {
         PageRequest pageRequest = PageRequest.of(request.getPageNumber(), request.getPageSize(), Sort.by(Sort.Order.desc("orderAt")));
         Page<Orders> orderList = orderRepository.findByOrderMemberId(userId, pageRequest);
         List<List<ProductDetail>> productDetailsByOrders =
-            orderList.stream().map(order -> order.getOrderItems().stream().map(orderItem -> productService.getProductDetail(orderItem.getProductId())).toList()).toList();
-
+            orderList.stream().map(order -> order.getOrderItems().stream().map(orderItem -> {
+                ProductDetail productDetail = productService.getProductDetail(orderItem.getProductId());
+                Map<Long, Long> optionMap = orderItem.getOrderItemOptions().stream()
+                    .collect(Collectors.toMap(
+                        OrderItemOption::getProductOptionId,
+                        OrderItemOption::getProductOptionDetailId,
+                        (existing, replacement) -> replacement
+                    ));
+                productDetail.getProductOptions().forEach(option -> {
+                    if (optionMap.containsKey(option.getId())) {
+                        option.updateOptionDetail(optionMap.get(option.getId()));
+                    }
+                });
+                return productDetail;
+            }).toList()).toList();
         List<UserOrder> userOrders = IntStream.range(0, orderList.getContent().size())
             .mapToObj(i -> UserOrder.from(orderList.getContent().get(i), productDetailsByOrders.get(i)))
             .toList();
 
-        // 최종적으로 Page<UserOrder> 반환
         return new PageImpl<>(userOrders, request, orderList.getTotalElements());
     }
 

--- a/order/src/main/java/com/emotionalcart/order/domain/dto/UserOrder.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/dto/UserOrder.java
@@ -42,8 +42,8 @@ public class UserOrder {
         this.orderStatus = orders.getStatus().getStatusName();
         this.orderAt = orders.getOrderAt();
         this.orderProductList =
-            IntStream.range(0, orders.getOrderItems().size()).mapToObj(i -> OrderProduct.from(orders.getOrderItems().get(i),
-                                                                                              productDetails.get(i))).toList();
+                IntStream.range(0, orders.getOrderItems().size()).mapToObj(i -> OrderProduct.from(orders.getOrderItems().get(i),
+                        productDetails.get(i))).toList();
     }
 
     public static UserOrder from(Orders orders, List<ProductDetail> productDetails) {
@@ -111,8 +111,8 @@ public class UserOrder {
 
             public static ProductOption from(ProductDetail.ProductDetailOption productDetailOption) {
                 return new ProductOption(productDetailOption.getId(),
-                                         productDetailOption.getName(),
-                                         productDetailOption.getOptionDetails());
+                        productDetailOption.getName(),
+                        productDetailOption.getOptionDetails());
             }
 
         }
@@ -123,11 +123,11 @@ public class UserOrder {
 
             private Long productOptionDetailId;
 
-            private String productOptionName;
+            private String productOptionDetailName;
 
             public ProductOptionDetail(ProductDetail.ProductOptionDetail productOptionDetail) {
                 this.productOptionDetailId = productOptionDetail.getId();
-                this.productOptionName = productOptionDetail.getValue();
+                this.productOptionDetailName = productOptionDetail.getValue();
             }
 
             public static ProductOptionDetail from(ProductDetail.ProductOptionDetail productOptionDetail) {

--- a/order/src/main/java/com/emotionalcart/order/domain/dto/UserOrder.java
+++ b/order/src/main/java/com/emotionalcart/order/domain/dto/UserOrder.java
@@ -69,6 +69,8 @@ public class UserOrder {
 
         private int quantity;
 
+        private List<ProductOption> productOptions;
+
         public OrderProduct(OrderItem orderItem, ProductDetail productDetail) {
             this.productId = orderItem.getProductId();
             this.providerId = productDetail.getProviderId();
@@ -77,10 +79,61 @@ public class UserOrder {
             this.productImage = productDetail.getProductImage();
             this.productPrice = orderItem.getItemPrice();
             this.quantity = orderItem.getQuantity();
+            this.productOptions = productDetail.getProductOptions().stream().map(ProductOption::from).toList();
         }
 
         public static OrderProduct from(OrderItem orderItem, ProductDetail productDetail) {
             return new OrderProduct(orderItem, productDetail);
+        }
+
+        @Getter
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        public static class ProductOption {
+
+            private Long productOptionId;
+
+            private String productOptionName;
+
+            private Long productOptionDetailId;
+
+            private String productOptionDetailName;
+
+            public ProductOption(Long id, String name, List<ProductDetail.ProductOptionDetail> optionDetails) {
+                this.productOptionId = id;
+                this.productOptionName = name;
+
+                if (!optionDetails.isEmpty()) {
+                    ProductDetail.ProductOptionDetail productOptionDetail = optionDetails.getFirst();
+                    this.productOptionDetailId = productOptionDetail.getId();
+                    this.productOptionDetailName = productOptionDetail.getValue();
+                }
+            }
+
+            public static ProductOption from(ProductDetail.ProductDetailOption productDetailOption) {
+                return new ProductOption(productDetailOption.getId(),
+                                         productDetailOption.getName(),
+                                         productDetailOption.getOptionDetails());
+            }
+
+        }
+
+        @Getter
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        public static class ProductOptionDetail {
+
+            private Long productOptionDetailId;
+
+            private String productOptionName;
+
+            public ProductOptionDetail(ProductDetail.ProductOptionDetail productOptionDetail) {
+                this.productOptionDetailId = productOptionDetail.getId();
+                this.productOptionName = productOptionDetail.getValue();
+            }
+
+            public static ProductOptionDetail from(ProductDetail.ProductOptionDetail productOptionDetail) {
+                return new ProductOptionDetail(productOptionDetail);
+            }
+
         }
 
     }

--- a/order/src/main/java/com/emotionalcart/order/infra/product/dto/ProductDetail.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/product/dto/ProductDetail.java
@@ -4,6 +4,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductDetail {
@@ -18,6 +20,8 @@ public class ProductDetail {
 
     private String productImage;
 
+    private List<ProductDetailOption> productOptions;
+
     public ProductDetail(ProductDetailResponse response) {
         this.productId = response.getId();
         this.productName = response.getName();
@@ -27,10 +31,62 @@ public class ProductDetail {
             response.getImages().stream().filter(image -> image.getType().toString().equals("MAIN")).map(ProductDetailResponse.ProductDetailImages::getUrl).findFirst().orElse(
                 "");
 
+        this.productOptions = response.getOptions().stream().map(ProductDetailOption::from).toList();
+
     }
 
     public static ProductDetail from(ProductDetailResponse responseBody) {
         return new ProductDetail(responseBody);
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProductDetailOption {
+
+        private Long id;
+
+        private String name;
+
+        private List<ProductOptionDetail> optionDetails;
+
+        public ProductDetailOption(Long id, String name, List<ProductDetailResponse.ProductOptionDetail> optionDetails) {
+            this.id = id;
+            this.name = name;
+            this.optionDetails = optionDetails.stream().map(ProductOptionDetail::from).toList();
+        }
+
+        public static ProductDetailOption from(ProductDetailResponse.ProductOption po) {
+            return new ProductDetailOption(po.getId(), po.getName(), po.getOptionDetails());
+        }
+
+        public void updateOptionDetail(Long optionItem) {
+            this.optionDetails = this.optionDetails.stream()
+                .filter(detail -> optionItem.equals(detail.getId()))
+                .toList();
+        }
+
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProductOptionDetail {
+
+        private Long id;
+        private String value;
+        private Integer order;
+        private Integer additionalPrice;
+
+        public ProductOptionDetail(Long id, String value, Integer order, Integer additionalPrice) {
+            this.id = id;
+            this.value = value;
+            this.order = order;
+            this.additionalPrice = additionalPrice;
+        }
+
+        public static ProductOptionDetail from(ProductDetailResponse.ProductOptionDetail od) {
+            return new ProductOptionDetail(od.getId(), od.getValue(), od.getOrder(), od.getAdditionalPrice());
+        }
+
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/infra/product/dto/ProductDetailResponse.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/product/dto/ProductDetailResponse.java
@@ -20,8 +20,12 @@ public class ProductDetailResponse {
     private String description;
     private Integer price;
     private ProductProvider provider;
+    private List<ProductOption> options;
     private List<ProductDetailImages> images;
 
+    /**
+     * 상품 이미지
+     */
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -38,6 +42,9 @@ public class ProductDetailResponse {
 
     }
 
+    /**
+     * 상품 업체
+     */
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -45,6 +52,37 @@ public class ProductDetailResponse {
 
         private Long id;
         private String name;
+
+    }
+
+    /**
+     * 상품 옵션
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ProductOption {
+
+        private Long id;
+
+        private String name;
+
+        private List<ProductOptionDetail> optionDetails;
+
+    }
+
+    /***
+     * 상품 옵션 상세
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ProductOptionDetail {
+
+        private Long id;
+        private String value;
+        private Integer order;
+        private Integer additionalPrice;
 
     }
 

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/response/UserOrderResponse.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/response/UserOrderResponse.java
@@ -103,6 +103,8 @@ public class UserOrderResponse {
         @Schema(description = "구매 수량", example = "1")
         private int quantity;
 
+        private List<ProductOption> productOptions;
+
         public OrderProduct(Long productId, String productName, int quantity, double orderItemPrice) {
             this.productId = productId;
             this.productName = productName;
@@ -118,6 +120,7 @@ public class UserOrderResponse {
             this.productPrice = orderProduct.getProductPrice();
             this.productImage = orderProduct.getProductImage();
             this.quantity = orderProduct.getQuantity();
+            this.productOptions = orderProduct.getProductOptions().stream().map(po -> ProductOption.from(po)).toList();
         }
 
         public static OrderProduct of(Long productId, String productName, int quantity, double orderItemPrice) {
@@ -126,6 +129,48 @@ public class UserOrderResponse {
 
         public static OrderProduct from(UserOrder.OrderProduct orderProduct) {
             return new OrderProduct(orderProduct);
+        }
+
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProductOption {
+
+        private Long productOptionId;
+        private String productOptionName;
+
+        private Long productOptionDetailId;
+        private String productOptionDetailName;
+
+        public ProductOption(UserOrder.OrderProduct.ProductOption po) {
+            this.productOptionId = po.getProductOptionId();
+            this.productOptionName = po.getProductOptionName();
+            this.productOptionDetailId = po.getProductOptionDetailId();
+            this.productOptionDetailName = po.getProductOptionDetailName();
+        }
+
+        public static ProductOption from(UserOrder.OrderProduct.ProductOption po) {
+            return new ProductOption(po);
+        }
+
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProductOptionDetail {
+
+        private Long productOptionDetailId;
+
+        private String productOptionDetailName;
+
+        public ProductOptionDetail(Long productOptionDetailId, String productOptionDetailName) {
+            this.productOptionDetailId = productOptionDetailId;
+            this.productOptionDetailName = productOptionDetailName;
+        }
+
+        public static ProductOptionDetail from(Long productOptionDetailId, String productOptionDetailName) {
+            return new ProductOptionDetail(productOptionDetailId, productOptionDetailName);
         }
 
     }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* 리뷰 등록 시 등록할 상품의 옵션 id 및 name을 포함하기 위해 주문내역내 response 추가

# 어떻게 해결했나요?

*

# 주의점 및 기타 사항

* 주문 내역 조회 시 상품 건 수마다 상품 상세 데이터를 조회해오고 있습니다. 다량의 상품 데이터 호출하는 로직이 없어 임시로 만들었는데 추후 수정이 필요해보입니다
