### PR TITLE
fix: 재고 조회시 토큰 제외

### DIFF
--- a/product/src/main/java/com/emotionalcart/core/config/FeignClientConfig.java
+++ b/product/src/main/java/com/emotionalcart/core/config/FeignClientConfig.java
@@ -18,20 +18,24 @@ public class FeignClientConfig {
 
     @Bean
     public RequestInterceptor requestInterceptor() {
-        return requestTemplate -> requestTemplate.header("Authorization", "Bearer " + getToken());
+        return requestTemplate -> {
+            if (!requestTemplate.url().contains("/quantity")) {
+                requestTemplate.header("Authorization", "Bearer " + getToken());
+            }
+        };
     }
 
     private String getToken() {
-        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        ServletRequestAttributes attributes = (ServletRequestAttributes)RequestContextHolder.getRequestAttributes();
         if (attributes == null) {
             throw new IllegalStateException("Request attributes are not available. Ensure this method is called in a web request context.");
         }
 
         return jwtHeaderValidator.obtainAuthorizationToken(attributes.getRequest())
-                .orElseThrow(() -> {
-                    log.error("JWT processing failed: Authorization token is missing.");
-                    return new IllegalStateException("Authorization token is required but missing.");
-                });
+            .orElseThrow(() -> {
+                log.error("JWT processing failed: Authorization token is missing.");
+                return new IllegalStateException("Authorization token is required but missing.");
+            });
     }
 
 }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

*  상품 조회시 토큰이 없을 수 있으나 재고 수량 조회시 feign client에서 토큰을 필수로 받고 있음

# 어떻게 해결했나요?

* 임시로 /quantity 호출시 토큰을 필수로 받지 않도록 함

# 주의점 및 기타 사항

* feign client 에서 토큰이 있으면 전달, 없어도 에러가 나지 않도록 하고,
* 각 도메인에서 토큰 없이 호출했을 경우 에러 전달하도록 수정이 필요해 보입니다.
