### PR TITLE
[common] Swagger에 운영 및 로컬 서버 API 동시 적용

### DIFF
--- a/auth/src/main/java/com/emotionalcart/core/config/SwaggerConfig.java
+++ b/auth/src/main/java/com/emotionalcart/core/config/SwaggerConfig.java
@@ -1,24 +1,38 @@
 package com.emotionalcart.core.config;
 
+import com.emotionalcart.common.swagger.SwaggerConfigProperties;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
+@RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
+
+    private final SwaggerConfigProperties swaggerConfigProperties;
 
     @Bean
     public GroupedOpenApi openAPI() {
         return GroupedOpenApi.builder()
-                .group("Group API")
-                .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo())).build();
+            .group("Group API")
+            .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo()).servers(servers())).build();
+    }
+
+    private List<Server> servers() {
+        return swaggerConfigProperties.getServers().stream()
+            .map(config -> new Server().url(config.getUrl()).description(config.getDescription()))
+            .toList();
     }
 
     private Info apiInfo() {
         return new Info()
-                .title("Auth API")
-                .description("인증 도메인 API Docs");
+            .title("Auth API")
+            .description("인증 도메인 API Docs");
     }
 
 }

--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -78,8 +78,13 @@ member:
     feign-endpoint: ${MEMBER_SERVER_URL:http://localhost:8081}
 server:
   port: 8082
-
 aws:
   s3:
     access-key: test
     secret-key: test
+swagger-config:
+  servers:
+    - url: https://auth-api.emmotional-cart.click
+      description: Production Server
+    - url: http://localhost:8082
+      description: Local Server

--- a/common/src/main/java/com/emotionalcart/common/swagger/SwaggerConfigProperties.java
+++ b/common/src/main/java/com/emotionalcart/common/swagger/SwaggerConfigProperties.java
@@ -1,0 +1,25 @@
+package com.emotionalcart.common.swagger;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "swagger-config")
+public class SwaggerConfigProperties {
+
+    private List<ServerDetail> servers;
+
+    @Data
+    public static class ServerDetail {
+
+        private String url;
+        private String description;
+
+    }
+
+}

--- a/member/src/main/java/com/emotionalcart/core/config/SwaggerConfig.java
+++ b/member/src/main/java/com/emotionalcart/core/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.emotionalcart.core.config;
 
+import com.emotionalcart.common.swagger.SwaggerConfigProperties;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
@@ -13,23 +14,25 @@ import java.util.List;
 @Configuration
 public class SwaggerConfig {
 
+    private final SwaggerConfigProperties swaggerConfigProperties;
+
     @Bean
     public GroupedOpenApi openAPI() {
         return GroupedOpenApi.builder()
-                .group("Group API")
-                .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo()).servers(servers())).build();
+            .group("Group API")
+            .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo()).servers(servers())).build();
     }
 
     private List<Server> servers() {
-        return List.of(
-                new Server().url("https://member-api.emmotional-cart.click").description("Production Server")
-        );
+        return swaggerConfigProperties.getServers().stream()
+            .map(config -> new Server().url(config.getUrl()).description(config.getDescription()))
+            .toList();
     }
 
     private Info apiInfo() {
         return new Info()
-                .title("Member API")
-                .description("회원 도메인 API Docs");
+            .title("Member API")
+            .description("회원 도메인 API Docs");
     }
 
 }

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -58,3 +58,9 @@ app:
     - https://member-api.emmotional-cart.click
     - https://product-api.emmotional-cart.click
     - https://order-api.emmotional-cart.click
+swagger-config:
+  servers:
+    - url: https://member-api.emmotional-cart.click
+      description: Production Server
+    - url: http://localhost:8081
+      description: Local Server

--- a/order/src/main/java/com/emotionalcart/order/infra/config/SwaggerConfig.java
+++ b/order/src/main/java/com/emotionalcart/order/infra/config/SwaggerConfig.java
@@ -1,32 +1,38 @@
 package com.emotionalcart.order.infra.config;
 
+import com.emotionalcart.common.swagger.SwaggerConfigProperties;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
+
+    private final SwaggerConfigProperties swaggerConfigProperties;
 
     @Bean
     public GroupedOpenApi openAPI() {
         return GroupedOpenApi.builder()
-                .group("Group API")
-                .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo()).servers(servers())).build();
+            .group("Group API")
+            .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo()).servers(servers())).build();
     }
 
     private List<Server> servers() {
-        return List.of(
-                new Server().url("https://order-api.emmotional-cart.click").description("Production Server")
-        );
+        return swaggerConfigProperties.getServers().stream()
+            .map(config -> new Server().url(config.getUrl()).description(config.getDescription()))
+            .toList();
     }
 
     private Info apiInfo() {
         return new Info()
-                .title("Order API")
-                .description("주문 도메인 API Docs");
+            .title("Order API")
+            .description("주문 도메인 API Docs");
     }
+
 }

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -40,3 +40,9 @@ stock:
 app:
   allow-domains:
     - https://order-api.emmotional-cart.click
+swagger-config:
+  servers:
+    - url: https://order-api.emmotional-cart.click
+      description: Production Server
+    - url: http://localhost:9999
+      description: Local Server

--- a/product/src/main/java/com/emotionalcart/core/config/SwaggerConfig.java
+++ b/product/src/main/java/com/emotionalcart/core/config/SwaggerConfig.java
@@ -1,33 +1,38 @@
 package com.emotionalcart.core.config;
 
+import com.emotionalcart.common.swagger.SwaggerConfigProperties;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
+
+    private final SwaggerConfigProperties swaggerConfigProperties;
 
     @Bean
     public GroupedOpenApi openAPI() {
         return GroupedOpenApi.builder()
-                .group("Group API")
-                .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo()).servers(servers())).build();
+            .group("Group API")
+            .addOpenApiCustomizer(openAPI -> openAPI.info(apiInfo()).servers(servers())).build();
     }
 
     private List<Server> servers() {
-        return List.of(
-                new Server().url("https://product-api.emmotional-cart.click").description("Production Server")
-        );
+        return swaggerConfigProperties.getServers().stream()
+            .map(config -> new Server().url(config.getUrl()).description(config.getDescription()))
+            .toList();
     }
 
     private Info apiInfo() {
         return new Info()
-                .title("Product API")
-                .description("상품 도메인 API Docs");
+            .title("Product API")
+            .description("상품 도메인 API Docs");
     }
 
 }

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -43,3 +43,9 @@ order:
 app:
   allow-domains:
     - https://product-api.emmotional-cart.click
+swagger-config:
+  servers:
+    - url: https://product-api.emmotional-cart.click
+      description: Production Server
+    - url: http://localhost:8080
+      description: Local Server


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* profiles 설정이 없어 환경별 분리가 어렵기 때문에, 운영 및 로컬 API를 모두 등록
* Swagger에서 호출할 수 있도록 모든 서버를 포함하도록 변경

![image](https://github.com/user-attachments/assets/99342d0c-b82a-4ea3-b7b8-bd066f23c2cd)


# 어떻게 해결했나요?

* 현재는 모든 환경에서 API를 다 포함하지만, 추후 profiles 기반 설정 개선 필요

# 주의점 및 기타 사항

* 현재는 모든 환경에서 API를 다 포함하지만, 추후 profiles 기반 설정 개선 필요
