### PR TITLE
feat : 사용자 주문 검증 후 응답 값 리턴

### DIFF
--- a/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
+++ b/order/src/main/java/com/emotionalcart/order/application/OrderDetailService.java
@@ -2,12 +2,15 @@ package com.emotionalcart.order.application;
 
 import com.emotionalcart.order.domain.dto.OrderDetail;
 import com.emotionalcart.order.domain.dto.UserOrder;
+import com.emotionalcart.order.domain.entity.OrderItem;
 import com.emotionalcart.order.domain.entity.OrderItemOption;
 import com.emotionalcart.order.domain.entity.Orders;
+import com.emotionalcart.order.infra.advice.exceptions.InvalidOrderException;
 import com.emotionalcart.order.infra.advice.exceptions.InvalidValueRequestException;
 import com.emotionalcart.order.infra.order.OrderRepository;
 import com.emotionalcart.order.infra.product.ProductService;
 import com.emotionalcart.order.infra.product.dto.ProductDetail;
+import com.emotionalcart.order.presentation.controller.response.ValidOrderResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -66,9 +69,25 @@ public class OrderDetailService {
         return new PageImpl<>(userOrders, request, orderList.getTotalElements());
     }
 
-    public Boolean validateOrderByMember(Long userId, Long orderId) {
-        return orderRepository.findByIdAndOrderMemberId(orderId, userId).isPresent() ? Boolean.TRUE : Boolean.FALSE;
+    public ValidOrderResponse validateOrderByMember(Long userId, Long orderId, Long productId) {
+        Orders orders = orderRepository.findByIdAndOrderMemberId(orderId, userId).orElseThrow(() -> new InvalidOrderException(
+            "일치하는 주문을 찾을 수 없습니다. 다시 확인 부탁드립니다."));
 
+        List<OrderItem> orderItems =
+            orders.getOrderItems().stream().filter(orderItem -> orderItem.getProductId().equals(productId)).toList();
+
+        if (!orderItems.isEmpty()) {
+            List<ValidOrderResponse.OrderDetailOption> orderDetailOptions = orderItems.stream()
+                .flatMap(orderItem -> orderItem.getOrderItemOptions().stream()
+                    .map(orderItemOption -> ValidOrderResponse.OrderDetailOption.from(
+                        orderItemOption.getProductOptionId(),
+                        orderItemOption.getProductOptionDetailId())))
+                .toList();
+
+            return ValidOrderResponse.of(productId, orderDetailOptions);
+        }
+
+        return ValidOrderResponse.empty();
     }
 
 }

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/OrderController.java
@@ -10,6 +10,7 @@ import com.emotionalcart.order.presentation.controller.request.CreateOrderReques
 import com.emotionalcart.order.presentation.controller.response.CreatedOrderResponse;
 import com.emotionalcart.order.presentation.controller.response.OrderDetailResponse;
 import com.emotionalcart.order.presentation.controller.response.UserOrderResponse;
+import com.emotionalcart.order.presentation.controller.response.ValidOrderResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -59,8 +60,10 @@ public class OrderController implements OrderApiDocs {
      * 사용자 주문 검증
      */
     @GetMapping("/users/validate/{orderId}")
-    public ResponseEntity<Boolean> validateOrderByMember(@AuthenticationPrincipal JwtAuthentication jwt, @PathVariable Long orderId) {
-        Boolean isExistOrder = orderDetailService.validateOrderByMember(jwt.id(), orderId);
+    public ResponseEntity<ValidOrderResponse> validateOrderByMember(@AuthenticationPrincipal JwtAuthentication jwt,
+                                                                    @PathVariable Long orderId,
+                                                                    @RequestParam Long productId) {
+        ValidOrderResponse isExistOrder = orderDetailService.validateOrderByMember(jwt.id(), orderId, productId);
         return ResponseEntity.ok().body(isExistOrder);
     }
 

--- a/order/src/main/java/com/emotionalcart/order/presentation/controller/response/ValidOrderResponse.java
+++ b/order/src/main/java/com/emotionalcart/order/presentation/controller/response/ValidOrderResponse.java
@@ -1,0 +1,49 @@
+package com.emotionalcart.order.presentation.controller.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ValidOrderResponse {
+
+    private Long productId;
+
+    private List<OrderDetailOption> productOptions;
+
+    public ValidOrderResponse(Long productId, List<OrderDetailOption> orderDetailOptions) {
+        this.productId = productId;
+        this.productOptions = orderDetailOptions;
+    }
+
+    public static ValidOrderResponse of(Long productId, List<OrderDetailOption> orderDetailOptions) {
+        return new ValidOrderResponse(productId, orderDetailOptions);
+    }
+
+    public static ValidOrderResponse empty() {
+        return new ValidOrderResponse();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class OrderDetailOption {
+
+        private Long productOptionId;
+
+        private Long productOptionDetailId;
+
+        public OrderDetailOption(Long productOptionId, Long productOptionDetailId) {
+            this.productOptionId = productOptionId;
+            this.productOptionDetailId = productOptionDetailId;
+        }
+
+        public static OrderDetailOption from(Long productOptionId, Long productOptionDetailId) {
+            return new OrderDetailOption(productOptionId, productOptionDetailId);
+        }
+
+    }
+
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

* requestParam 추가 및 응답값 전달
* http://localhost:9999/api/v1/orders/users/validate/4017564917289276836?productId=4004431091503561665

```json
{
  "productId": 4004431091503561700,
  "productOptions": [
    {
      "productOptionId": 4004431091915683000,
      "productOptionDetailId": 4004431091914229000
    },
    {
      "productOptionId": 4004431091917370400,
      "productOptionDetailId": 4004431091922541000
    }
  ]
}

```

# 어떻게 해결했나요?

*

## Attachment

* 관련 업무 링크 추가!
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## PN 규칙

p1 : 적극적으로 고려해주세요 (Request changes)
리뷰를 받아들이거나 그럴수 없다면 토론을 해보자

p2 : 웬만하면 반영해 주세요 (Comment)
리뷰를 받아들이거나 그럴수 없다면 다음에 반영할 계획을 명시적으로(업무) 표현하자

p3 : 반영해도 좋고 넘어가도 좋습니다. (Approve)
의견에 대해 고민해보자

p4 : 그냥 사소한 의견입니다. (Approve)

# 주의점 및 기타 사항

* 
